### PR TITLE
v5 - new major version

### DIFF
--- a/src/IGDB.php
+++ b/src/IGDB.php
@@ -6,13 +6,14 @@
      * Fethching data from IGDB's database.
      * Compatible with IGDB API v4
      *
-     * @version 4.3.2
+     * @version 5.0.0
      * @author Enisz Abdalla <enisz87@gmail.com>
      * @link https://github.com/enisz/igdb
      */
 
     require_once "IGDBEndpointException.php";
     require_once "IGDBInvalidParameterException.php";
+    require_once "IGDBConstants.php";
 
     class IGDB {
 
@@ -37,11 +38,6 @@
         private $request_info;
 
         /**
-         * IGDB API Url
-         */
-        private $api_url = "https://api.igdb.com/v4";
-
-        /**
          * Instantiates the IGDB object
          *
          * @param $client_id Your Client ID
@@ -61,7 +57,7 @@
             $this->curl_handler = curl_init();
             curl_setopt($this->curl_handler, CURLOPT_SSL_VERIFYPEER, false);
             curl_setopt($this->curl_handler, CURLOPT_RETURNTRANSFER, true);
-            curl_setopt($this->curl_handler, CURLOPT_POST, true);
+            curl_setopt($this->curl_handler, CURLOPT_CUSTOMREQUEST, "POST");
             curl_setopt($this->curl_handler, CURLOPT_HTTPHEADER, array(
                 "Client-ID: $this->client_id",
                 "Authorization: Bearer $this->access_token"
@@ -83,65 +79,8 @@
          * @return string - the constructed URL using the provided parameters
          */
         public function construct_url($endpoint, $count = false) {
-            $endpoints = array(
-                "age_rating" => "age_ratings",
-                "age_rating_content_description" => "age_rating_content_descriptions",
-                "alternative_name" => "alternative_names",
-                "artwork" => "artworks",
-                "character" => "characters",
-                "character_mug_shot" => "character_mug_shots",
-                "collection" => "collections",
-                "collection_membership" => "collection_memberships",
-                "collection_membership_type" => "collection_membership_types",
-                "collection_relation" => "collection_relations",
-                "collection_relation_type" => "collection_relation_types",
-                "collection_type" => "collection_types",
-                "company" => "companies",
-                "company_logo" => "company_logos",
-                "company_website" => "company_websites",
-                "cover" => "covers",
-                "event" => "events",
-                "event_logo" => "event_logos",
-                "event_network" => "event_networks",
-                "external_game" => "external_games",
-                "franchise" => "franchises",
-                "game" => "games",
-                "game_engine" => "game_engines",
-                "game_engine_logo" => "game_engine_logos",
-                "game_localization" => "game_localizations",
-                "game_mode" => "game_modes",
-                "game_version" => "game_versions",
-                "game_version_feature" => "game_version_features",
-                "game_version_feature_value" => "game_version_feature_values",
-                "game_video" => "game_videos",
-                "genre" => "genres",
-                "involved_company" => "involved_companies",
-                "keyword" => "keywords",
-                "language" => "languages",
-                "language_support" => "language_supports",
-                "language_support_type" => "language_support_types",
-                "multiplayer_mode" => "multiplayer_modes",
-                "multiquery" => "multiquery",
-                "network_type" => "network_types",
-                "platform" => "platforms",
-                "platform_family" => "platform_families",
-                "platform_logo" => "platform_logos",
-                "platform_version" => "platform_versions",
-                "platform_version_company" => "platform_version_companies",
-                "platform_version_release_date" => "platform_version_release_dates",
-                "platform_website" => "platform_websites",
-                "player_perspective" => "player_perspectives",
-                "region" => "regions",
-                "release_date" => "release_dates",
-                "release_date_status" => "release_date_statuses",
-                "screenshot" => "screenshots",
-                "search" => "search",
-                "theme" => "themes",
-                "website" => "websites",
-            );
-
-            if(array_key_exists($endpoint, $endpoints)) {
-                return rtrim($this->api_url, "/") . "/" . $endpoints[$endpoint] . ($count ? "/count" : "");
+            if(array_key_exists($endpoint, IGDBW_ENDPOINTS)) {
+                return rtrim(IGDBW_API_URL, "/") . "/" . IGDBW_ENDPOINTS[$endpoint] . ($count ? "/count" : "");
             } else {
                 throw new IGDBInvalidParameterException("Invalid Endpoint name " . $endpoint . "!");
             }
@@ -152,8 +91,9 @@
          * Returns an array of objects decoded from IGDB JSON response or throws Exception in case of error
          *
          * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @param $url ( string ) The url of the endpoint
-         * @param $query ( string ) The apicalypse query string to send
+         * @param $query ( string | IGDBQueryBuilder ) query to send to IGDB
          * @return $result ( array ) The response objects from IGDB in an array.
          */
         private function _exec_query($url, $query) {
@@ -161,11 +101,15 @@
                 $this->curl_reinit();
             }
 
+            if(!is_string($query) && !($query instanceof IGDBQueryBuilder)) {
+                throw new IGDBInvalidParameterException("Type of query has to be either a string or an IGDBQueryBuilder instance instead of " . gettype($query) . "!");
+            }
+
             // Set the request URL
             curl_setopt($this->curl_handler, CURLOPT_URL, $url);
 
             // Set the body of the request
-            curl_setopt($this->curl_handler, CURLOPT_POSTFIELDS, $query);
+            curl_setopt($this->curl_handler, CURLOPT_POSTFIELDS, is_string($query) ? $query : $query->build());
 
             // Executing and decoding the request
             $result = json_decode(curl_exec($this->curl_handler));
@@ -174,19 +118,20 @@
             $this->request_info = curl_getinfo($this->curl_handler);
 
             // HTTP response code
-            $response_code = $this->request_info['http_code'];
+            $response_code = curl_getinfo($this->curl_handler, CURLINFO_HTTP_CODE);
 
             // If there were errors
             if($response_code < 200 || $response_code > 299) {
+                var_dump($result);
                 $message = "Something went wrong with your query! Use <a href=\"https://enisz.github.io/igdb/documentation#get-request-info\" target=\"_blank\">get_request_info()</a> method to see the details of your query!";
 
                 if(is_array($result) && is_object($result[0])) {
-                    if(property_exists($result[0], "cause")) {
-                        $message = $result[0]->cause;
-                    }
-
                     if(property_exists($result[0], "title")) {
                         $message = $result[0]->title;
+                    }
+
+                    if(property_exists($result[0], "cause")) {
+                        $message .= ': ' . $result[0]->cause;
                     }
                 }
 
@@ -229,974 +174,1508 @@
          * @param $queries ( array of strings ) The queries to send to the multiquery endpoint as an array of multiquery formatted apicalypse strings.
          * @return $result ( mixed ) The result of the query.
          * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @throws IGDBInvalidParameterException If not array of strings is passed as a parameter
+         * @throws IGDBInvalidParameterException If not array of strings or IGDBQueryBuilder instances are passed as a parameter
          */
         public function multiquery($queries) {
-            if(gettype($queries) == "array") {
+            $prepared = array();
+
+            if(is_array($queries)) {
                 foreach($queries as $index => $query) {
-                    if(gettype($query) != "string") {
-                        throw new IGDBInvalidParameterException("Invalid type of parameter for multiquery! An array of strings is expected, " . gettype($query) . " passed at index " . $index . "!");
+                    if(!is_string($query) && !($query instanceof IGDBQueryBuilder)) {
+                        throw new IGDBInvalidParameterException("Invalid type of parameter for multiquery! An array of strings or IGDBQueryBuilder instances are expected, " . gettype($query) . " passed at index " . $index . "!");
                     }
+
+                    array_push($prepared, is_string($query) ? $query : $query->build_multiquery());
                 }
             } else {
                 throw new IGDBInvalidParameterException("Invalid type of parameter for multiquery! An array is expected, " . gettype($queries) . " passed!");
             }
 
-            return $this->_exec_query($this->construct_url(__FUNCTION__, false), implode("\n\n", $queries));
+            return $this->_exec_query($this->construct_url(__FUNCTION__, false), implode("\n\n", $prepared));
         }
 
         /**
          * Age Rating according to various rating organisations
          *
-         * Depending on $count, the method will either return:
-         *  - <code>TRUE</code>: an object containing a <code>count</code> property with the number of matched records
-         *  - <code>FALSE</code>: an array of objects, containing the matched records from IGDB
+         * @link https://api-docs.igdb.com/#age-rating
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result array entities from IGDB matching the query
+         */
+        public function age_rating($query) {
+            return $this->_exec_query($this->construct_url('age_rating', false), $query);
+        }
+
+        /**
+         * Age Rating according to various rating organisations
          *
          * @link https://api-docs.igdb.com/#age-rating
          *
-         * @param $query ( string ) an apicalypse query string to send to the IGDB server
-         * @param $count ( boolean ) whether the method should return the results or their count.
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
          * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @return $result ( array | object ) response from IGDB
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result integer number of entities from IGDB matching the query
          */
-        public function age_rating($query, $count = false) {
-            return $this->_exec_query($this->construct_url(__FUNCTION__, $count), $query);
+        public function age_rating_count($query) {
+            return $this->_exec_query($this->construct_url('age_rating', true), $query)->count;
         }
 
         /**
          * Age Rating Descriptors
          *
-         * Depending on $count, the method will either return:
-         *  - <code>TRUE</code>: an object containing a <code>count</code> property with the number of matched records
-         *  - <code>FALSE</code>: an array of objects, containing the matched records from IGDB
+         * @link https://api-docs.igdb.com/#age-rating-content-description
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result array entities from IGDB matching the query
+         */
+        public function age_rating_content_description($query) {
+            return $this->_exec_query($this->construct_url('age_rating_content_description', false), $query);
+        }
+
+        /**
+         * Age Rating Descriptors
          *
          * @link https://api-docs.igdb.com/#age-rating-content-description
          *
-         * @param $query ( string ) an apicalypse query string to send to the IGDB server
-         * @param $count ( boolean ) whether the method should return the results or their count.
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
          * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @return $result ( array | object ) response from IGDB
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result integer number of entities from IGDB matching the query
          */
-        public function age_rating_content_description($query, $count = false) {
-            return $this->_exec_query($this->construct_url(__FUNCTION__, $count), $query);
+        public function age_rating_content_description_count($query) {
+            return $this->_exec_query($this->construct_url('age_rating_content_description', true), $query)->count;
         }
 
         /**
          * Alternative and international game titles
          *
-         * Depending on $count, the method will either return:
-         *  - <code>TRUE</code>: an object containing a <code>count</code> property with the number of matched records
-         *  - <code>FALSE</code>: an array of objects, containing the matched records from IGDB
+         * @link https://api-docs.igdb.com/#alternative-name
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result array entities from IGDB matching the query
+         */
+        public function alternative_name($query) {
+            return $this->_exec_query($this->construct_url('alternative_name', false), $query);
+        }
+
+        /**
+         * Alternative and international game titles
          *
          * @link https://api-docs.igdb.com/#alternative-name
          *
-         * @param $query ( string ) an apicalypse query string to send to the IGDB server
-         * @param $count ( boolean ) whether the method should return the results or their count.
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
          * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @return $result ( array | object ) response from IGDB
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result integer number of entities from IGDB matching the query
          */
-        public function alternative_name($query, $count = false) {
-            return $this->_exec_query($this->construct_url(__FUNCTION__, $count), $query);
+        public function alternative_name_count($query) {
+            return $this->_exec_query($this->construct_url('alternative_name', true), $query)->count;
         }
 
         /**
          * official artworks (resolution and aspect ratio may vary)
          *
-         * Depending on $count, the method will either return:
-         *  - <code>TRUE</code>: an object containing a <code>count</code> property with the number of matched records
-         *  - <code>FALSE</code>: an array of objects, containing the matched records from IGDB
+         * @link https://api-docs.igdb.com/#artwork
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result array entities from IGDB matching the query
+         */
+        public function artwork($query) {
+            return $this->_exec_query($this->construct_url('artwork', false), $query);
+        }
+
+        /**
+         * official artworks (resolution and aspect ratio may vary)
          *
          * @link https://api-docs.igdb.com/#artwork
          *
-         * @param $query ( string ) an apicalypse query string to send to the IGDB server
-         * @param $count ( boolean ) whether the method should return the results or their count.
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
          * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @return $result ( array | object ) response from IGDB
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result integer number of entities from IGDB matching the query
          */
-        public function artwork($query, $count = false) {
-            return $this->_exec_query($this->construct_url(__FUNCTION__, $count), $query);
+        public function artwork_count($query) {
+            return $this->_exec_query($this->construct_url('artwork', true), $query)->count;
         }
 
         /**
          * Video game characters
          *
-         * Depending on $count, the method will either return:
-         *  - <code>TRUE</code>: an object containing a <code>count</code> property with the number of matched records
-         *  - <code>FALSE</code>: an array of objects, containing the matched records from IGDB
+         * @link https://api-docs.igdb.com/#character
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result array entities from IGDB matching the query
+         */
+        public function character($query) {
+            return $this->_exec_query($this->construct_url('character', false), $query);
+        }
+
+        /**
+         * Video game characters
          *
          * @link https://api-docs.igdb.com/#character
          *
-         * @param $query ( string ) an apicalypse query string to send to the IGDB server
-         * @param $count ( boolean ) whether the method should return the results or their count.
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
          * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @return $result ( array | object ) response from IGDB
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result integer number of entities from IGDB matching the query
          */
-        public function character($query, $count = false) {
-            return $this->_exec_query($this->construct_url(__FUNCTION__, $count), $query);
+        public function character_count($query) {
+            return $this->_exec_query($this->construct_url('character', true), $query)->count;
         }
 
         /**
          * Images depicting game characters
          *
-         * Depending on $count, the method will either return:
-         *  - <code>TRUE</code>: an object containing a <code>count</code> property with the number of matched records
-         *  - <code>FALSE</code>: an array of objects, containing the matched records from IGDB
+         * @link https://api-docs.igdb.com/#character-mug-shot
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result array entities from IGDB matching the query
+         */
+        public function character_mug_shot($query) {
+            return $this->_exec_query($this->construct_url('character_mug_shot', false), $query);
+        }
+
+        /**
+         * Images depicting game characters
          *
          * @link https://api-docs.igdb.com/#character-mug-shot
          *
-         * @param $query ( string ) an apicalypse query string to send to the IGDB server
-         * @param $count ( boolean ) whether the method should return the results or their count.
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
          * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @return $result ( array | object ) response from IGDB
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result integer number of entities from IGDB matching the query
          */
-        public function character_mug_shot($query, $count = false) {
-            return $this->_exec_query($this->construct_url(__FUNCTION__, $count), $query);
+        public function character_mug_shot_count($query) {
+            return $this->_exec_query($this->construct_url('character_mug_shot', true), $query)->count;
         }
 
         /**
          * Collection, AKA Series
          *
-         * Depending on $count, the method will either return:
-         *  - <code>TRUE</code>: an object containing a <code>count</code> property with the number of matched records
-         *  - <code>FALSE</code>: an array of objects, containing the matched records from IGDB
+         * @link https://api-docs.igdb.com/#collection
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result array entities from IGDB matching the query
+         */
+        public function collection($query) {
+            return $this->_exec_query($this->construct_url('collection', false), $query);
+        }
+
+        /**
+         * Collection, AKA Series
          *
          * @link https://api-docs.igdb.com/#collection
          *
-         * @param $query ( string ) an apicalypse query string to send to the IGDB server
-         * @param $count ( boolean ) whether the method should return the results or their count.
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
          * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @return $result ( array | object ) response from IGDB
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result integer number of entities from IGDB matching the query
          */
-        public function collection($query, $count = false) {
-            return $this->_exec_query($this->construct_url(__FUNCTION__, $count), $query);
+        public function collection_count($query) {
+            return $this->_exec_query($this->construct_url('collection', true), $query)->count;
         }
 
         /**
          * The Collection Memberships.
          *
-         * Depending on $count, the method will either return:
-         *  - <code>TRUE</code>: an object containing a <code>count</code> property with the number of matched records
-         *  - <code>FALSE</code>: an array of objects, containing the matched records from IGDB
+         * @link https://api-docs.igdb.com/#collection-membership
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result array entities from IGDB matching the query
+         */
+        public function collection_membership($query) {
+            return $this->_exec_query($this->construct_url('collection_membership', false), $query);
+        }
+
+        /**
+         * The Collection Memberships.
          *
          * @link https://api-docs.igdb.com/#collection-membership
          *
-         * @param $query ( string ) an apicalypse query string to send to the IGDB server
-         * @param $count ( boolean ) whether the method should return the results or their count.
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
          * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @return $result ( array | object ) response from IGDB
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result integer number of entities from IGDB matching the query
          */
-        public function collection_membership($query, $count = false) {
-            return $this->_exec_query($this->construct_url(__FUNCTION__, $count), $query);
+        public function collection_membership_count($query) {
+            return $this->_exec_query($this->construct_url('collection_membership', true), $query)->count;
         }
 
         /**
          * Enums for collection membership types.
          *
-         * Depending on $count, the method will either return:
-         *  - <code>TRUE</code>: an object containing a <code>count</code> property with the number of matched records
-         *  - <code>FALSE</code>: an array of objects, containing the matched records from IGDB
+         * @link https://api-docs.igdb.com/#collection-membership-type
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result array entities from IGDB matching the query
+         */
+        public function collection_membership_type($query) {
+            return $this->_exec_query($this->construct_url('collection_membership_type', false), $query);
+        }
+
+        /**
+         * Enums for collection membership types.
          *
          * @link https://api-docs.igdb.com/#collection-membership-type
          *
-         * @param $query ( string ) an apicalypse query string to send to the IGDB server
-         * @param $count ( boolean ) whether the method should return the results or their count.
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
          * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @return $result ( array | object ) response from IGDB
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result integer number of entities from IGDB matching the query
          */
-        public function collection_membership_type($query, $count = false) {
-            return $this->_exec_query($this->construct_url(__FUNCTION__, $count), $query);
+        public function collection_membership_type_count($query) {
+            return $this->_exec_query($this->construct_url('collection_membership_type', true), $query)->count;
         }
 
         /**
          * Describes Relationship between Collections.
          *
-         * Depending on $count, the method will either return:
-         *  - <code>TRUE</code>: an object containing a <code>count</code> property with the number of matched records
-         *  - <code>FALSE</code>: an array of objects, containing the matched records from IGDB
+         * @link https://api-docs.igdb.com/#collection-relation
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result array entities from IGDB matching the query
+         */
+        public function collection_relation($query) {
+            return $this->_exec_query($this->construct_url('collection_relation', false), $query);
+        }
+
+        /**
+         * Describes Relationship between Collections.
          *
          * @link https://api-docs.igdb.com/#collection-relation
          *
-         * @param $query ( string ) an apicalypse query string to send to the IGDB server
-         * @param $count ( boolean ) whether the method should return the results or their count.
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
          * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @return $result ( array | object ) response from IGDB
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result integer number of entities from IGDB matching the query
          */
-        public function collection_relation($query, $count = false) {
-            return $this->_exec_query($this->construct_url(__FUNCTION__, $count), $query);
+        public function collection_relation_count($query) {
+            return $this->_exec_query($this->construct_url('collection_relation', true), $query)->count;
         }
 
         /**
          * Collection Relation Types
          *
-         * Depending on $count, the method will either return:
-         *  - <code>TRUE</code>: an object containing a <code>count</code> property with the number of matched records
-         *  - <code>FALSE</code>: an array of objects, containing the matched records from IGDB
+         * @link https://api-docs.igdb.com/#collection-relation-type
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result array entities from IGDB matching the query
+         */
+        public function collection_relation_type($query) {
+            return $this->_exec_query($this->construct_url('collection_relation_type', false), $query);
+        }
+
+        /**
+         * Collection Relation Types
          *
          * @link https://api-docs.igdb.com/#collection-relation-type
          *
-         * @param $query ( string ) an apicalypse query string to send to the IGDB server
-         * @param $count ( boolean ) whether the method should return the results or their count.
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
          * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @return $result ( array | object ) response from IGDB
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result integer number of entities from IGDB matching the query
          */
-        public function collection_relation_type($query, $count = false) {
-            return $this->_exec_query($this->construct_url(__FUNCTION__, $count), $query);
+        public function collection_relation_type_count($query) {
+            return $this->_exec_query($this->construct_url('collection_relation_type', true), $query)->count;
         }
 
         /**
          * Enums for collection types.
          *
-         * Depending on $count, the method will either return:
-         *  - <code>TRUE</code>: an object containing a <code>count</code> property with the number of matched records
-         *  - <code>FALSE</code>: an array of objects, containing the matched records from IGDB
-         *
          * @link https://api-docs.igdb.com/#collection-type
          *
-         * @param $query ( string ) an apicalypse query string to send to the IGDB server
-         * @param $count ( boolean ) whether the method should return the results or their count.
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
          * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @return $result ( array | object ) response from IGDB
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result array entities from IGDB matching the query
          */
-        public function collection_type($query, $count = false) {
-            return $this->_exec_query($this->construct_url(__FUNCTION__, $count), $query);
+        public function collection_type($query) {
+            return $this->_exec_query($this->construct_url('collection_type', false), $query);
         }
 
         /**
-         * Video game companies. Both publishers & developers
+         * Enums for collection types.
          *
-         * Depending on $count, the method will either return:
-         *  - <code>TRUE</code>: an object containing a <code>count</code> property with the number of matched records
-         *  - <code>FALSE</code>: an array of objects, containing the matched records from IGDB
+         * @link https://api-docs.igdb.com/#collection-type
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result integer number of entities from IGDB matching the query
+         */
+        public function collection_type_count($query) {
+            return $this->_exec_query($this->construct_url('collection_type', true), $query)->count;
+        }
+
+        /**
+         * Video game companies. Both publishers &amp; developers
          *
          * @link https://api-docs.igdb.com/#company
          *
-         * @param $query ( string ) an apicalypse query string to send to the IGDB server
-         * @param $count ( boolean ) whether the method should return the results or their count.
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
          * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @return $result ( array | object ) response from IGDB
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result array entities from IGDB matching the query
          */
-        public function company($query, $count = false) {
-            return $this->_exec_query($this->construct_url(__FUNCTION__, $count), $query);
+        public function company($query) {
+            return $this->_exec_query($this->construct_url('company', false), $query);
+        }
+
+        /**
+         * Video game companies. Both publishers &amp; developers
+         *
+         * @link https://api-docs.igdb.com/#company
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result integer number of entities from IGDB matching the query
+         */
+        public function company_count($query) {
+            return $this->_exec_query($this->construct_url('company', true), $query)->count;
         }
 
         /**
          * The logos of developers and publishers
          *
-         * Depending on $count, the method will either return:
-         *  - <code>TRUE</code>: an object containing a <code>count</code> property with the number of matched records
-         *  - <code>FALSE</code>: an array of objects, containing the matched records from IGDB
+         * @link https://api-docs.igdb.com/#company-logo
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result array entities from IGDB matching the query
+         */
+        public function company_logo($query) {
+            return $this->_exec_query($this->construct_url('company_logo', false), $query);
+        }
+
+        /**
+         * The logos of developers and publishers
          *
          * @link https://api-docs.igdb.com/#company-logo
          *
-         * @param $query ( string ) an apicalypse query string to send to the IGDB server
-         * @param $count ( boolean ) whether the method should return the results or their count.
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
          * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @return $result ( array | object ) response from IGDB
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result integer number of entities from IGDB matching the query
          */
-        public function company_logo($query, $count = false) {
-            return $this->_exec_query($this->construct_url(__FUNCTION__, $count), $query);
+        public function company_logo_count($query) {
+            return $this->_exec_query($this->construct_url('company_logo', true), $query)->count;
         }
 
         /**
          * Company Website
          *
-         * Depending on $count, the method will either return:
-         *  - <code>TRUE</code>: an object containing a <code>count</code> property with the number of matched records
-         *  - <code>FALSE</code>: an array of objects, containing the matched records from IGDB
+         * @link https://api-docs.igdb.com/#company-website
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result array entities from IGDB matching the query
+         */
+        public function company_website($query) {
+            return $this->_exec_query($this->construct_url('company_website', false), $query);
+        }
+
+        /**
+         * Company Website
          *
          * @link https://api-docs.igdb.com/#company-website
          *
-         * @param $query ( string ) an apicalypse query string to send to the IGDB server
-         * @param $count ( boolean ) whether the method should return the results or their count.
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
          * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @return $result ( array | object ) response from IGDB
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result integer number of entities from IGDB matching the query
          */
-        public function company_website($query, $count = false) {
-            return $this->_exec_query($this->construct_url(__FUNCTION__, $count), $query);
+        public function company_website_count($query) {
+            return $this->_exec_query($this->construct_url('company_website', true), $query)->count;
         }
 
         /**
          * The cover art of games
          *
-         * Depending on $count, the method will either return:
-         *  - <code>TRUE</code>: an object containing a <code>count</code> property with the number of matched records
-         *  - <code>FALSE</code>: an array of objects, containing the matched records from IGDB
+         * @link https://api-docs.igdb.com/#cover
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result array entities from IGDB matching the query
+         */
+        public function cover($query) {
+            return $this->_exec_query($this->construct_url('cover', false), $query);
+        }
+
+        /**
+         * The cover art of games
          *
          * @link https://api-docs.igdb.com/#cover
          *
-         * @param $query ( string ) an apicalypse query string to send to the IGDB server
-         * @param $count ( boolean ) whether the method should return the results or their count.
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
          * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @return $result ( array | object ) response from IGDB
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result integer number of entities from IGDB matching the query
          */
-        public function cover($query, $count = false) {
-            return $this->_exec_query($this->construct_url(__FUNCTION__, $count), $query);
+        public function cover_count($query) {
+            return $this->_exec_query($this->construct_url('cover', true), $query)->count;
         }
 
         /**
          * Gaming event like GamesCom, Tokyo Game Show, PAX or GSL
          *
-         * Depending on $count, the method will either return:
-         *  - <code>TRUE</code>: an object containing a <code>count</code> property with the number of matched records
-         *  - <code>FALSE</code>: an array of objects, containing the matched records from IGDB
+         * @link https://api-docs.igdb.com/#event
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result array entities from IGDB matching the query
+         */
+        public function event($query) {
+            return $this->_exec_query($this->construct_url('event', false), $query);
+        }
+
+        /**
+         * Gaming event like GamesCom, Tokyo Game Show, PAX or GSL
          *
          * @link https://api-docs.igdb.com/#event
          *
-         * @param $query ( string ) an apicalypse query string to send to the IGDB server
-         * @param $count ( boolean ) whether the method should return the results or their count.
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
          * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @return $result ( array | object ) response from IGDB
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result integer number of entities from IGDB matching the query
          */
-        public function event($query, $count = false) {
-            return $this->_exec_query($this->construct_url(__FUNCTION__, $count), $query);
+        public function event_count($query) {
+            return $this->_exec_query($this->construct_url('event', true), $query)->count;
         }
 
         /**
          * Logo for the event
          *
-         * Depending on $count, the method will either return:
-         *  - <code>TRUE</code>: an object containing a <code>count</code> property with the number of matched records
-         *  - <code>FALSE</code>: an array of objects, containing the matched records from IGDB
+         * @link https://api-docs.igdb.com/#event-logo
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result array entities from IGDB matching the query
+         */
+        public function event_logo($query) {
+            return $this->_exec_query($this->construct_url('event_logo', false), $query);
+        }
+
+        /**
+         * Logo for the event
          *
          * @link https://api-docs.igdb.com/#event-logo
          *
-         * @param $query ( string ) an apicalypse query string to send to the IGDB server
-         * @param $count ( boolean ) whether the method should return the results or their count.
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
          * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @return $result ( array | object ) response from IGDB
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result integer number of entities from IGDB matching the query
          */
-        public function event_logo($query, $count = false) {
-            return $this->_exec_query($this->construct_url(__FUNCTION__, $count), $query);
+        public function event_logo_count($query) {
+            return $this->_exec_query($this->construct_url('event_logo', true), $query)->count;
         }
 
         /**
          * Urls related to the event like twitter, facebook and youtube
          *
-         * Depending on $count, the method will either return:
-         *  - <code>TRUE</code>: an object containing a <code>count</code> property with the number of matched records
-         *  - <code>FALSE</code>: an array of objects, containing the matched records from IGDB
+         * @link https://api-docs.igdb.com/#event-network
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result array entities from IGDB matching the query
+         */
+        public function event_network($query) {
+            return $this->_exec_query($this->construct_url('event_network', false), $query);
+        }
+
+        /**
+         * Urls related to the event like twitter, facebook and youtube
          *
          * @link https://api-docs.igdb.com/#event-network
          *
-         * @param $query ( string ) an apicalypse query string to send to the IGDB server
-         * @param $count ( boolean ) whether the method should return the results or their count.
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
          * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @return $result ( array | object ) response from IGDB
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result integer number of entities from IGDB matching the query
          */
-        public function event_network($query, $count = false) {
-            return $this->_exec_query($this->construct_url(__FUNCTION__, $count), $query);
+        public function event_network_count($query) {
+            return $this->_exec_query($this->construct_url('event_network', true), $query)->count;
         }
 
         /**
          * Game IDs on other services
          *
-         * Depending on $count, the method will either return:
-         *  - <code>TRUE</code>: an object containing a <code>count</code> property with the number of matched records
-         *  - <code>FALSE</code>: an array of objects, containing the matched records from IGDB
+         * @link https://api-docs.igdb.com/#external-game
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result array entities from IGDB matching the query
+         */
+        public function external_game($query) {
+            return $this->_exec_query($this->construct_url('external_game', false), $query);
+        }
+
+        /**
+         * Game IDs on other services
          *
          * @link https://api-docs.igdb.com/#external-game
          *
-         * @param $query ( string ) an apicalypse query string to send to the IGDB server
-         * @param $count ( boolean ) whether the method should return the results or their count.
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
          * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @return $result ( array | object ) response from IGDB
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result integer number of entities from IGDB matching the query
          */
-        public function external_game($query, $count = false) {
-            return $this->_exec_query($this->construct_url(__FUNCTION__, $count), $query);
+        public function external_game_count($query) {
+            return $this->_exec_query($this->construct_url('external_game', true), $query)->count;
         }
 
         /**
          * A list of video game franchises such as Star Wars.
          *
-         * Depending on $count, the method will either return:
-         *  - <code>TRUE</code>: an object containing a <code>count</code> property with the number of matched records
-         *  - <code>FALSE</code>: an array of objects, containing the matched records from IGDB
+         * @link https://api-docs.igdb.com/#franchise
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result array entities from IGDB matching the query
+         */
+        public function franchise($query) {
+            return $this->_exec_query($this->construct_url('franchise', false), $query);
+        }
+
+        /**
+         * A list of video game franchises such as Star Wars.
          *
          * @link https://api-docs.igdb.com/#franchise
          *
-         * @param $query ( string ) an apicalypse query string to send to the IGDB server
-         * @param $count ( boolean ) whether the method should return the results or their count.
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
          * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @return $result ( array | object ) response from IGDB
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result integer number of entities from IGDB matching the query
          */
-        public function franchise($query, $count = false) {
-            return $this->_exec_query($this->construct_url(__FUNCTION__, $count), $query);
+        public function franchise_count($query) {
+            return $this->_exec_query($this->construct_url('franchise', true), $query)->count;
         }
 
         /**
          * Video Games!
          *
-         * Depending on $count, the method will either return:
-         *  - <code>TRUE</code>: an object containing a <code>count</code> property with the number of matched records
-         *  - <code>FALSE</code>: an array of objects, containing the matched records from IGDB
+         * @link https://api-docs.igdb.com/#game
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result array entities from IGDB matching the query
+         */
+        public function game($query) {
+            return $this->_exec_query($this->construct_url('game', false), $query);
+        }
+
+        /**
+         * Video Games!
          *
          * @link https://api-docs.igdb.com/#game
          *
-         * @param $query ( string ) an apicalypse query string to send to the IGDB server
-         * @param $count ( boolean ) whether the method should return the results or their count.
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
          * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @return $result ( array | object ) response from IGDB
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result integer number of entities from IGDB matching the query
          */
-        public function game($query, $count = false) {
-            return $this->_exec_query($this->construct_url(__FUNCTION__, $count), $query);
+        public function game_count($query) {
+            return $this->_exec_query($this->construct_url('game', true), $query)->count;
         }
 
         /**
          * Video game engines such as unreal engine.
          *
-         * Depending on $count, the method will either return:
-         *  - <code>TRUE</code>: an object containing a <code>count</code> property with the number of matched records
-         *  - <code>FALSE</code>: an array of objects, containing the matched records from IGDB
+         * @link https://api-docs.igdb.com/#game-engine
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result array entities from IGDB matching the query
+         */
+        public function game_engine($query) {
+            return $this->_exec_query($this->construct_url('game_engine', false), $query);
+        }
+
+        /**
+         * Video game engines such as unreal engine.
          *
          * @link https://api-docs.igdb.com/#game-engine
          *
-         * @param $query ( string ) an apicalypse query string to send to the IGDB server
-         * @param $count ( boolean ) whether the method should return the results or their count.
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
          * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @return $result ( array | object ) response from IGDB
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result integer number of entities from IGDB matching the query
          */
-        public function game_engine($query, $count = false) {
-            return $this->_exec_query($this->construct_url(__FUNCTION__, $count), $query);
+        public function game_engine_count($query) {
+            return $this->_exec_query($this->construct_url('game_engine', true), $query)->count;
         }
 
         /**
          * The logos of game engines
          *
-         * Depending on $count, the method will either return:
-         *  - <code>TRUE</code>: an object containing a <code>count</code> property with the number of matched records
-         *  - <code>FALSE</code>: an array of objects, containing the matched records from IGDB
+         * @link https://api-docs.igdb.com/#game-engine-logo
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result array entities from IGDB matching the query
+         */
+        public function game_engine_logo($query) {
+            return $this->_exec_query($this->construct_url('game_engine_logo', false), $query);
+        }
+
+        /**
+         * The logos of game engines
          *
          * @link https://api-docs.igdb.com/#game-engine-logo
          *
-         * @param $query ( string ) an apicalypse query string to send to the IGDB server
-         * @param $count ( boolean ) whether the method should return the results or their count.
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
          * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @return $result ( array | object ) response from IGDB
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result integer number of entities from IGDB matching the query
          */
-        public function game_engine_logo($query, $count = false) {
-            return $this->_exec_query($this->construct_url(__FUNCTION__, $count), $query);
+        public function game_engine_logo_count($query) {
+            return $this->_exec_query($this->construct_url('game_engine_logo', true), $query)->count;
         }
 
         /**
          * Game localization for a game
          *
-         * Depending on $count, the method will either return:
-         *  - <code>TRUE</code>: an object containing a <code>count</code> property with the number of matched records
-         *  - <code>FALSE</code>: an array of objects, containing the matched records from IGDB
+         * @link https://api-docs.igdb.com/#game-localization
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result array entities from IGDB matching the query
+         */
+        public function game_localization($query) {
+            return $this->_exec_query($this->construct_url('game_localization', false), $query);
+        }
+
+        /**
+         * Game localization for a game
          *
          * @link https://api-docs.igdb.com/#game-localization
          *
-         * @param $query ( string ) an apicalypse query string to send to the IGDB server
-         * @param $count ( boolean ) whether the method should return the results or their count.
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
          * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @return $result ( array | object ) response from IGDB
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result integer number of entities from IGDB matching the query
          */
-        public function game_localization($query, $count = false) {
-            return $this->_exec_query($this->construct_url(__FUNCTION__, $count), $query);
+        public function game_localization_count($query) {
+            return $this->_exec_query($this->construct_url('game_localization', true), $query)->count;
         }
 
         /**
          * Single player, Multiplayer etc
          *
-         * Depending on $count, the method will either return:
-         *  - <code>TRUE</code>: an object containing a <code>count</code> property with the number of matched records
-         *  - <code>FALSE</code>: an array of objects, containing the matched records from IGDB
+         * @link https://api-docs.igdb.com/#game-mode
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result array entities from IGDB matching the query
+         */
+        public function game_mode($query) {
+            return $this->_exec_query($this->construct_url('game_mode', false), $query);
+        }
+
+        /**
+         * Single player, Multiplayer etc
          *
          * @link https://api-docs.igdb.com/#game-mode
          *
-         * @param $query ( string ) an apicalypse query string to send to the IGDB server
-         * @param $count ( boolean ) whether the method should return the results or their count.
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
          * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @return $result ( array | object ) response from IGDB
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result integer number of entities from IGDB matching the query
          */
-        public function game_mode($query, $count = false) {
-            return $this->_exec_query($this->construct_url(__FUNCTION__, $count), $query);
+        public function game_mode_count($query) {
+            return $this->_exec_query($this->construct_url('game_mode', true), $query)->count;
         }
 
         /**
          * Details about game editions and versions.
          *
-         * Depending on $count, the method will either return:
-         *  - <code>TRUE</code>: an object containing a <code>count</code> property with the number of matched records
-         *  - <code>FALSE</code>: an array of objects, containing the matched records from IGDB
+         * @link https://api-docs.igdb.com/#game-version
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result array entities from IGDB matching the query
+         */
+        public function game_version($query) {
+            return $this->_exec_query($this->construct_url('game_version', false), $query);
+        }
+
+        /**
+         * Details about game editions and versions.
          *
          * @link https://api-docs.igdb.com/#game-version
          *
-         * @param $query ( string ) an apicalypse query string to send to the IGDB server
-         * @param $count ( boolean ) whether the method should return the results or their count.
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
          * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @return $result ( array | object ) response from IGDB
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result integer number of entities from IGDB matching the query
          */
-        public function game_version($query, $count = false) {
-            return $this->_exec_query($this->construct_url(__FUNCTION__, $count), $query);
+        public function game_version_count($query) {
+            return $this->_exec_query($this->construct_url('game_version', true), $query)->count;
         }
 
         /**
          * Features and descriptions of what makes each version&#x2F;edition different from the main game
          *
-         * Depending on $count, the method will either return:
-         *  - <code>TRUE</code>: an object containing a <code>count</code> property with the number of matched records
-         *  - <code>FALSE</code>: an array of objects, containing the matched records from IGDB
+         * @link https://api-docs.igdb.com/#game-version-feature
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result array entities from IGDB matching the query
+         */
+        public function game_version_feature($query) {
+            return $this->_exec_query($this->construct_url('game_version_feature', false), $query);
+        }
+
+        /**
+         * Features and descriptions of what makes each version&#x2F;edition different from the main game
          *
          * @link https://api-docs.igdb.com/#game-version-feature
          *
-         * @param $query ( string ) an apicalypse query string to send to the IGDB server
-         * @param $count ( boolean ) whether the method should return the results or their count.
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
          * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @return $result ( array | object ) response from IGDB
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result integer number of entities from IGDB matching the query
          */
-        public function game_version_feature($query, $count = false) {
-            return $this->_exec_query($this->construct_url(__FUNCTION__, $count), $query);
+        public function game_version_feature_count($query) {
+            return $this->_exec_query($this->construct_url('game_version_feature', true), $query)->count;
         }
 
         /**
          * The bool&#x2F;text value of the feature
          *
-         * Depending on $count, the method will either return:
-         *  - <code>TRUE</code>: an object containing a <code>count</code> property with the number of matched records
-         *  - <code>FALSE</code>: an array of objects, containing the matched records from IGDB
+         * @link https://api-docs.igdb.com/#game-version-feature-value
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result array entities from IGDB matching the query
+         */
+        public function game_version_feature_value($query) {
+            return $this->_exec_query($this->construct_url('game_version_feature_value', false), $query);
+        }
+
+        /**
+         * The bool&#x2F;text value of the feature
          *
          * @link https://api-docs.igdb.com/#game-version-feature-value
          *
-         * @param $query ( string ) an apicalypse query string to send to the IGDB server
-         * @param $count ( boolean ) whether the method should return the results or their count.
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
          * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @return $result ( array | object ) response from IGDB
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result integer number of entities from IGDB matching the query
          */
-        public function game_version_feature_value($query, $count = false) {
-            return $this->_exec_query($this->construct_url(__FUNCTION__, $count), $query);
+        public function game_version_feature_value_count($query) {
+            return $this->_exec_query($this->construct_url('game_version_feature_value', true), $query)->count;
         }
 
         /**
          * A video associated with a game
          *
-         * Depending on $count, the method will either return:
-         *  - <code>TRUE</code>: an object containing a <code>count</code> property with the number of matched records
-         *  - <code>FALSE</code>: an array of objects, containing the matched records from IGDB
+         * @link https://api-docs.igdb.com/#game-video
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result array entities from IGDB matching the query
+         */
+        public function game_video($query) {
+            return $this->_exec_query($this->construct_url('game_video', false), $query);
+        }
+
+        /**
+         * A video associated with a game
          *
          * @link https://api-docs.igdb.com/#game-video
          *
-         * @param $query ( string ) an apicalypse query string to send to the IGDB server
-         * @param $count ( boolean ) whether the method should return the results or their count.
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
          * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @return $result ( array | object ) response from IGDB
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result integer number of entities from IGDB matching the query
          */
-        public function game_video($query, $count = false) {
-            return $this->_exec_query($this->construct_url(__FUNCTION__, $count), $query);
+        public function game_video_count($query) {
+            return $this->_exec_query($this->construct_url('game_video', true), $query)->count;
         }
 
         /**
          * Genres of video game
          *
-         * Depending on $count, the method will either return:
-         *  - <code>TRUE</code>: an object containing a <code>count</code> property with the number of matched records
-         *  - <code>FALSE</code>: an array of objects, containing the matched records from IGDB
+         * @link https://api-docs.igdb.com/#genre
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result array entities from IGDB matching the query
+         */
+        public function genre($query) {
+            return $this->_exec_query($this->construct_url('genre', false), $query);
+        }
+
+        /**
+         * Genres of video game
          *
          * @link https://api-docs.igdb.com/#genre
          *
-         * @param $query ( string ) an apicalypse query string to send to the IGDB server
-         * @param $count ( boolean ) whether the method should return the results or their count.
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
          * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @return $result ( array | object ) response from IGDB
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result integer number of entities from IGDB matching the query
          */
-        public function genre($query, $count = false) {
-            return $this->_exec_query($this->construct_url(__FUNCTION__, $count), $query);
+        public function genre_count($query) {
+            return $this->_exec_query($this->construct_url('genre', true), $query)->count;
         }
 
         /**
          *
          *
-         * Depending on $count, the method will either return:
-         *  - <code>TRUE</code>: an object containing a <code>count</code> property with the number of matched records
-         *  - <code>FALSE</code>: an array of objects, containing the matched records from IGDB
+         * @link https://api-docs.igdb.com/#involved-company
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result array entities from IGDB matching the query
+         */
+        public function involved_company($query) {
+            return $this->_exec_query($this->construct_url('involved_company', false), $query);
+        }
+
+        /**
+         *
          *
          * @link https://api-docs.igdb.com/#involved-company
          *
-         * @param $query ( string ) an apicalypse query string to send to the IGDB server
-         * @param $count ( boolean ) whether the method should return the results or their count.
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
          * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @return $result ( array | object ) response from IGDB
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result integer number of entities from IGDB matching the query
          */
-        public function involved_company($query, $count = false) {
-            return $this->_exec_query($this->construct_url(__FUNCTION__, $count), $query);
+        public function involved_company_count($query) {
+            return $this->_exec_query($this->construct_url('involved_company', true), $query)->count;
         }
 
         /**
          * Keywords are words or phrases that get tagged to a game such as &quot;world war 2&quot; or &quot;steampunk&quot;.
          *
-         * Depending on $count, the method will either return:
-         *  - <code>TRUE</code>: an object containing a <code>count</code> property with the number of matched records
-         *  - <code>FALSE</code>: an array of objects, containing the matched records from IGDB
-         *
          * @link https://api-docs.igdb.com/#keyword
          *
-         * @param $query ( string ) an apicalypse query string to send to the IGDB server
-         * @param $count ( boolean ) whether the method should return the results or their count.
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
          * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @return $result ( array | object ) response from IGDB
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result array entities from IGDB matching the query
          */
-        public function keyword($query, $count = false) {
-            return $this->_exec_query($this->construct_url(__FUNCTION__, $count), $query);
+        public function keyword($query) {
+            return $this->_exec_query($this->construct_url('keyword', false), $query);
         }
 
         /**
-         * Languages that are used in the Language Support endpoint.
+         * Keywords are words or phrases that get tagged to a game such as &quot;world war 2&quot; or &quot;steampunk&quot;.
          *
-         * Depending on $count, the method will either return:
-         *  - <code>TRUE</code>: an object containing a <code>count</code> property with the number of matched records
-         *  - <code>FALSE</code>: an array of objects, containing the matched records from IGDB
+         * @link https://api-docs.igdb.com/#keyword
          *
-         * @link https://api-docs.igdb.com/#language
-         *
-         * @param $query ( string ) an apicalypse query string to send to the IGDB server
-         * @param $count ( boolean ) whether the method should return the results or their count.
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
          * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @return $result ( array | object ) response from IGDB
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result integer number of entities from IGDB matching the query
          */
-        public function language($query, $count = false) {
-            return $this->_exec_query($this->construct_url(__FUNCTION__, $count), $query);
+        public function keyword_count($query) {
+            return $this->_exec_query($this->construct_url('keyword', true), $query)->count;
         }
 
         /**
          * Games can be played with different languages for voice acting, subtitles, or the interface language.
          *
-         * Depending on $count, the method will either return:
-         *  - <code>TRUE</code>: an object containing a <code>count</code> property with the number of matched records
-         *  - <code>FALSE</code>: an array of objects, containing the matched records from IGDB
+         * @link https://api-docs.igdb.com/#language-support
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result array entities from IGDB matching the query
+         */
+        public function language_support($query) {
+            return $this->_exec_query($this->construct_url('language_support', false), $query);
+        }
+
+        /**
+         * Games can be played with different languages for voice acting, subtitles, or the interface language.
          *
          * @link https://api-docs.igdb.com/#language-support
          *
-         * @param $query ( string ) an apicalypse query string to send to the IGDB server
-         * @param $count ( boolean ) whether the method should return the results or their count.
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
          * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @return $result ( array | object ) response from IGDB
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result integer number of entities from IGDB matching the query
          */
-        public function language_support($query, $count = false) {
-            return $this->_exec_query($this->construct_url(__FUNCTION__, $count), $query);
-        }
-
-        /**
-         * Data about the supported multiplayer types
-         *
-         * Depending on $count, the method will either return:
-         *  - <code>TRUE</code>: an object containing a <code>count</code> property with the number of matched records
-         *  - <code>FALSE</code>: an array of objects, containing the matched records from IGDB
-         *
-         * @link https://api-docs.igdb.com/#multiplayer-mode
-         *
-         * @param $query ( string ) an apicalypse query string to send to the IGDB server
-         * @param $count ( boolean ) whether the method should return the results or their count.
-         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @return $result ( array | object ) response from IGDB
-         */
-        public function multiplayer_mode($query, $count = false) {
-            return $this->_exec_query($this->construct_url(__FUNCTION__, $count), $query);
-        }
-
-        /**
-         * The hardware used to run the game or game delivery network
-         *
-         * Depending on $count, the method will either return:
-         *  - <code>TRUE</code>: an object containing a <code>count</code> property with the number of matched records
-         *  - <code>FALSE</code>: an array of objects, containing the matched records from IGDB
-         *
-         * @link https://api-docs.igdb.com/#platform
-         *
-         * @param $query ( string ) an apicalypse query string to send to the IGDB server
-         * @param $count ( boolean ) whether the method should return the results or their count.
-         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @return $result ( array | object ) response from IGDB
-         */
-        public function platform($query, $count = false) {
-            return $this->_exec_query($this->construct_url(__FUNCTION__, $count), $query);
+        public function language_support_count($query) {
+            return $this->_exec_query($this->construct_url('language_support', true), $query)->count;
         }
 
         /**
          * Language Support Types contains the identifiers for the support types that Language Support uses.
          *
-         * Depending on $count, the method will either return:
-         *  - <code>TRUE</code>: an object containing a <code>count</code> property with the number of matched records
-         *  - <code>FALSE</code>: an array of objects, containing the matched records from IGDB
-         *
          * @link https://api-docs.igdb.com/#language-support-type
          *
-         * @param $query ( string ) an apicalypse query string to send to the IGDB server
-         * @param $count ( boolean ) whether the method should return the results or their count.
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
          * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @return $result ( array | object ) response from IGDB
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result array entities from IGDB matching the query
          */
-        public function language_support_type($query, $count = false) {
-            return $this->_exec_query($this->construct_url(__FUNCTION__, $count), $query);
+        public function language_support_type($query) {
+            return $this->_exec_query($this->construct_url('language_support_type', false), $query);
         }
 
         /**
-         * A collection of closely related platforms
+         * Language Support Types contains the identifiers for the support types that Language Support uses.
          *
-         * Depending on $count, the method will either return:
-         *  - <code>TRUE</code>: an object containing a <code>count</code> property with the number of matched records
-         *  - <code>FALSE</code>: an array of objects, containing the matched records from IGDB
+         * @link https://api-docs.igdb.com/#language-support-type
          *
-         * @link https://api-docs.igdb.com/#platform-family
-         *
-         * @param $query ( string ) an apicalypse query string to send to the IGDB server
-         * @param $count ( boolean ) whether the method should return the results or their count.
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
          * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @return $result ( array | object ) response from IGDB
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result integer number of entities from IGDB matching the query
          */
-        public function platform_family($query, $count = false) {
-            return $this->_exec_query($this->construct_url(__FUNCTION__, $count), $query);
+        public function language_support_type_count($query) {
+            return $this->_exec_query($this->construct_url('language_support_type', true), $query)->count;
+        }
+
+        /**
+         * Languages that are used in the Language Support endpoint.
+         *
+         * @link https://api-docs.igdb.com/#language
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result array entities from IGDB matching the query
+         */
+        public function language($query) {
+            return $this->_exec_query($this->construct_url('language', false), $query);
+        }
+
+        /**
+         * Languages that are used in the Language Support endpoint.
+         *
+         * @link https://api-docs.igdb.com/#language
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result integer number of entities from IGDB matching the query
+         */
+        public function language_count($query) {
+            return $this->_exec_query($this->construct_url('language', true), $query)->count;
+        }
+
+        /**
+         * Data about the supported multiplayer types
+         *
+         * @link https://api-docs.igdb.com/#multiplayer-mode
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result array entities from IGDB matching the query
+         */
+        public function multiplayer_mode($query) {
+            return $this->_exec_query($this->construct_url('multiplayer_mode', false), $query);
+        }
+
+        /**
+         * Data about the supported multiplayer types
+         *
+         * @link https://api-docs.igdb.com/#multiplayer-mode
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result integer number of entities from IGDB matching the query
+         */
+        public function multiplayer_mode_count($query) {
+            return $this->_exec_query($this->construct_url('multiplayer_mode', true), $query)->count;
         }
 
         /**
          * Social networks related to the event like twitter, facebook and youtube
          *
-         * Depending on $count, the method will either return:
-         *  - <code>TRUE</code>: an object containing a <code>count</code> property with the number of matched records
-         *  - <code>FALSE</code>: an array of objects, containing the matched records from IGDB
+         * @link https://api-docs.igdb.com/#network-type
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result array entities from IGDB matching the query
+         */
+        public function network_type($query) {
+            return $this->_exec_query($this->construct_url('network_type', false), $query);
+        }
+
+        /**
+         * Social networks related to the event like twitter, facebook and youtube
          *
          * @link https://api-docs.igdb.com/#network-type
          *
-         * @param $query ( string ) an apicalypse query string to send to the IGDB server
-         * @param $count ( boolean ) whether the method should return the results or their count.
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
          * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @return $result ( array | object ) response from IGDB
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result integer number of entities from IGDB matching the query
          */
-        public function network_type($query, $count = false) {
-            return $this->_exec_query($this->construct_url(__FUNCTION__, $count), $query);
+        public function network_type_count($query) {
+            return $this->_exec_query($this->construct_url('network_type', true), $query)->count;
+        }
+
+        /**
+         * The hardware used to run the game or game delivery network
+         *
+         * @link https://api-docs.igdb.com/#platform
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result array entities from IGDB matching the query
+         */
+        public function platform($query) {
+            return $this->_exec_query($this->construct_url('platform', false), $query);
+        }
+
+        /**
+         * The hardware used to run the game or game delivery network
+         *
+         * @link https://api-docs.igdb.com/#platform
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result integer number of entities from IGDB matching the query
+         */
+        public function platform_count($query) {
+            return $this->_exec_query($this->construct_url('platform', true), $query)->count;
+        }
+
+        /**
+         * A collection of closely related platforms
+         *
+         * @link https://api-docs.igdb.com/#platform-family
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result array entities from IGDB matching the query
+         */
+        public function platform_family($query) {
+            return $this->_exec_query($this->construct_url('platform_family', false), $query);
+        }
+
+        /**
+         * A collection of closely related platforms
+         *
+         * @link https://api-docs.igdb.com/#platform-family
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result integer number of entities from IGDB matching the query
+         */
+        public function platform_family_count($query) {
+            return $this->_exec_query($this->construct_url('platform_family', true), $query)->count;
         }
 
         /**
          * Logo for a platform
          *
-         * Depending on $count, the method will either return:
-         *  - <code>TRUE</code>: an object containing a <code>count</code> property with the number of matched records
-         *  - <code>FALSE</code>: an array of objects, containing the matched records from IGDB
+         * @link https://api-docs.igdb.com/#platform-logo
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result array entities from IGDB matching the query
+         */
+        public function platform_logo($query) {
+            return $this->_exec_query($this->construct_url('platform_logo', false), $query);
+        }
+
+        /**
+         * Logo for a platform
          *
          * @link https://api-docs.igdb.com/#platform-logo
          *
-         * @param $query ( string ) an apicalypse query string to send to the IGDB server
-         * @param $count ( boolean ) whether the method should return the results or their count.
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
          * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @return $result ( array | object ) response from IGDB
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result integer number of entities from IGDB matching the query
          */
-        public function platform_logo($query, $count = false) {
-            return $this->_exec_query($this->construct_url(__FUNCTION__, $count), $query);
+        public function platform_logo_count($query) {
+            return $this->_exec_query($this->construct_url('platform_logo', true), $query)->count;
+        }
+
+        /**
+         *
+         *
+         * @link https://api-docs.igdb.com/#platform-version
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result array entities from IGDB matching the query
+         */
+        public function platform_version($query) {
+            return $this->_exec_query($this->construct_url('platform_version', false), $query);
+        }
+
+        /**
+         *
+         *
+         * @link https://api-docs.igdb.com/#platform-version
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result integer number of entities from IGDB matching the query
+         */
+        public function platform_version_count($query) {
+            return $this->_exec_query($this->construct_url('platform_version', true), $query)->count;
         }
 
         /**
          * A platform developer
          *
-         * Depending on $count, the method will either return:
-         *  - <code>TRUE</code>: an object containing a <code>count</code> property with the number of matched records
-         *  - <code>FALSE</code>: an array of objects, containing the matched records from IGDB
+         * @link https://api-docs.igdb.com/#platform-version-company
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result array entities from IGDB matching the query
+         */
+        public function platform_version_company($query) {
+            return $this->_exec_query($this->construct_url('platform_version_company', false), $query);
+        }
+
+        /**
+         * A platform developer
          *
          * @link https://api-docs.igdb.com/#platform-version-company
          *
-         * @param $query ( string ) an apicalypse query string to send to the IGDB server
-         * @param $count ( boolean ) whether the method should return the results or their count.
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
          * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @return $result ( array | object ) response from IGDB
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result integer number of entities from IGDB matching the query
          */
-        public function platform_version_company($query, $count = false) {
-            return $this->_exec_query($this->construct_url(__FUNCTION__, $count), $query);
-        }
-
-        /**
-         *
-         *
-         * Depending on $count, the method will either return:
-         *  - <code>TRUE</code>: an object containing a <code>count</code> property with the number of matched records
-         *  - <code>FALSE</code>: an array of objects, containing the matched records from IGDB
-         *
-         * @link https://api-docs.igdb.com/#platform-version
-         *
-         * @param $query ( string ) an apicalypse query string to send to the IGDB server
-         * @param $count ( boolean ) whether the method should return the results or their count.
-         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @return $result ( array | object ) response from IGDB
-         */
-        public function platform_version($query, $count = false) {
-            return $this->_exec_query($this->construct_url(__FUNCTION__, $count), $query);
-        }
-
-        /**
-         * The main website for the platform
-         *
-         * Depending on $count, the method will either return:
-         *  - <code>TRUE</code>: an object containing a <code>count</code> property with the number of matched records
-         *  - <code>FALSE</code>: an array of objects, containing the matched records from IGDB
-         *
-         * @link https://api-docs.igdb.com/#platform-website
-         *
-         * @param $query ( string ) an apicalypse query string to send to the IGDB server
-         * @param $count ( boolean ) whether the method should return the results or their count.
-         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @return $result ( array | object ) response from IGDB
-         */
-        public function platform_website($query, $count = false) {
-            return $this->_exec_query($this->construct_url(__FUNCTION__, $count), $query);
+        public function platform_version_company_count($query) {
+            return $this->_exec_query($this->construct_url('platform_version_company', true), $query)->count;
         }
 
         /**
          * A handy endpoint that extends platform release dates. Used to dig deeper into release dates, platforms and versions.
          *
-         * Depending on $count, the method will either return:
-         *  - <code>TRUE</code>: an object containing a <code>count</code> property with the number of matched records
-         *  - <code>FALSE</code>: an array of objects, containing the matched records from IGDB
+         * @link https://api-docs.igdb.com/#platform-version-release-date
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result array entities from IGDB matching the query
+         */
+        public function platform_version_release_date($query) {
+            return $this->_exec_query($this->construct_url('platform_version_release_date', false), $query);
+        }
+
+        /**
+         * A handy endpoint that extends platform release dates. Used to dig deeper into release dates, platforms and versions.
          *
          * @link https://api-docs.igdb.com/#platform-version-release-date
          *
-         * @param $query ( string ) an apicalypse query string to send to the IGDB server
-         * @param $count ( boolean ) whether the method should return the results or their count.
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
          * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @return $result ( array | object ) response from IGDB
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result integer number of entities from IGDB matching the query
          */
-        public function platform_version_release_date($query, $count = false) {
-            return $this->_exec_query($this->construct_url(__FUNCTION__, $count), $query);
+        public function platform_version_release_date_count($query) {
+            return $this->_exec_query($this->construct_url('platform_version_release_date', true), $query)->count;
+        }
+
+        /**
+         * The main website for the platform
+         *
+         * @link https://api-docs.igdb.com/#platform-website
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result array entities from IGDB matching the query
+         */
+        public function platform_website($query) {
+            return $this->_exec_query($this->construct_url('platform_website', false), $query);
+        }
+
+        /**
+         * The main website for the platform
+         *
+         * @link https://api-docs.igdb.com/#platform-website
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result integer number of entities from IGDB matching the query
+         */
+        public function platform_website_count($query) {
+            return $this->_exec_query($this->construct_url('platform_website', true), $query)->count;
         }
 
         /**
          * Player perspectives describe the view&#x2F;perspective of the player in a video game.
          *
-         * Depending on $count, the method will either return:
-         *  - <code>TRUE</code>: an object containing a <code>count</code> property with the number of matched records
-         *  - <code>FALSE</code>: an array of objects, containing the matched records from IGDB
+         * @link https://api-docs.igdb.com/#player-perspective
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result array entities from IGDB matching the query
+         */
+        public function player_perspective($query) {
+            return $this->_exec_query($this->construct_url('player_perspective', false), $query);
+        }
+
+        /**
+         * Player perspectives describe the view&#x2F;perspective of the player in a video game.
          *
          * @link https://api-docs.igdb.com/#player-perspective
          *
-         * @param $query ( string ) an apicalypse query string to send to the IGDB server
-         * @param $count ( boolean ) whether the method should return the results or their count.
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
          * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @return $result ( array | object ) response from IGDB
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result integer number of entities from IGDB matching the query
          */
-        public function player_perspective($query, $count = false) {
-            return $this->_exec_query($this->construct_url(__FUNCTION__, $count), $query);
+        public function player_perspective_count($query) {
+            return $this->_exec_query($this->construct_url('player_perspective', true), $query)->count;
         }
 
         /**
          * Region for game localization
          *
-         * Depending on $count, the method will either return:
-         *  - <code>TRUE</code>: an object containing a <code>count</code> property with the number of matched records
-         *  - <code>FALSE</code>: an array of objects, containing the matched records from IGDB
+         * @link https://api-docs.igdb.com/#region
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result array entities from IGDB matching the query
+         */
+        public function region($query) {
+            return $this->_exec_query($this->construct_url('region', false), $query);
+        }
+
+        /**
+         * Region for game localization
          *
          * @link https://api-docs.igdb.com/#region
          *
-         * @param $query ( string ) an apicalypse query string to send to the IGDB server
-         * @param $count ( boolean ) whether the method should return the results or their count.
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
          * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @return $result ( array | object ) response from IGDB
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result integer number of entities from IGDB matching the query
          */
-        public function region($query, $count = false) {
-            return $this->_exec_query($this->construct_url(__FUNCTION__, $count), $query);
+        public function region_count($query) {
+            return $this->_exec_query($this->construct_url('region', true), $query)->count;
         }
 
         /**
          * A handy endpoint that extends game release dates. Used to dig deeper into release dates, platforms and versions.
          *
-         * Depending on $count, the method will either return:
-         *  - <code>TRUE</code>: an object containing a <code>count</code> property with the number of matched records
-         *  - <code>FALSE</code>: an array of objects, containing the matched records from IGDB
+         * @link https://api-docs.igdb.com/#release-date
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result array entities from IGDB matching the query
+         */
+        public function release_date($query) {
+            return $this->_exec_query($this->construct_url('release_date', false), $query);
+        }
+
+        /**
+         * A handy endpoint that extends game release dates. Used to dig deeper into release dates, platforms and versions.
          *
          * @link https://api-docs.igdb.com/#release-date
          *
-         * @param $query ( string ) an apicalypse query string to send to the IGDB server
-         * @param $count ( boolean ) whether the method should return the results or their count.
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
          * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @return $result ( array | object ) response from IGDB
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result integer number of entities from IGDB matching the query
          */
-        public function release_date($query, $count = false) {
-            return $this->_exec_query($this->construct_url(__FUNCTION__, $count), $query);
+        public function release_date_count($query) {
+            return $this->_exec_query($this->construct_url('release_date', true), $query)->count;
         }
 
         /**
          * An endpoint to provide definition of all of the current release date statuses.
          *
-         * Depending on $count, the method will either return:
-         *  - <code>TRUE</code>: an object containing a <code>count</code> property with the number of matched records
-         *  - <code>FALSE</code>: an array of objects, containing the matched records from IGDB
+         * @link https://api-docs.igdb.com/#release-date-status
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result array entities from IGDB matching the query
+         */
+        public function release_date_status($query) {
+            return $this->_exec_query($this->construct_url('release_date_status', false), $query);
+        }
+
+        /**
+         * An endpoint to provide definition of all of the current release date statuses.
          *
          * @link https://api-docs.igdb.com/#release-date-status
          *
-         * @param $query ( string ) an apicalypse query string to send to the IGDB server
-         * @param $count ( boolean ) whether the method should return the results or their count.
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
          * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @return $result ( array | object ) response from IGDB
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result integer number of entities from IGDB matching the query
          */
-        public function release_date_status($query, $count = false) {
-            return $this->_exec_query($this->construct_url(__FUNCTION__, $count), $query);
+        public function release_date_status_count($query) {
+            return $this->_exec_query($this->construct_url('release_date_status', true), $query)->count;
         }
 
         /**
          * Screenshots of games
          *
-         * Depending on $count, the method will either return:
-         *  - <code>TRUE</code>: an object containing a <code>count</code> property with the number of matched records
-         *  - <code>FALSE</code>: an array of objects, containing the matched records from IGDB
+         * @link https://api-docs.igdb.com/#screenshot
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result array entities from IGDB matching the query
+         */
+        public function screenshot($query) {
+            return $this->_exec_query($this->construct_url('screenshot', false), $query);
+        }
+
+        /**
+         * Screenshots of games
          *
          * @link https://api-docs.igdb.com/#screenshot
          *
-         * @param $query ( string ) an apicalypse query string to send to the IGDB server
-         * @param $count ( boolean ) whether the method should return the results or their count.
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
          * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @return $result ( array | object ) response from IGDB
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result integer number of entities from IGDB matching the query
          */
-        public function screenshot($query, $count = false) {
-            return $this->_exec_query($this->construct_url(__FUNCTION__, $count), $query);
+        public function screenshot_count($query) {
+            return $this->_exec_query($this->construct_url('screenshot', true), $query)->count;
         }
 
         /**
          *
          *
-         * Depending on $count, the method will either return:
-         *  - <code>TRUE</code>: an object containing a <code>count</code> property with the number of matched records
-         *  - <code>FALSE</code>: an array of objects, containing the matched records from IGDB
+         * @link https://api-docs.igdb.com/#search
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result array entities from IGDB matching the query
+         */
+        public function search($query) {
+            return $this->_exec_query($this->construct_url('search', false), $query);
+        }
+
+        /**
+         *
          *
          * @link https://api-docs.igdb.com/#search
          *
-         * @param $query ( string ) an apicalypse query string to send to the IGDB server
-         * @param $count ( boolean ) whether the method should return the results or their count.
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
          * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @return $result ( array | object ) response from IGDB
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result integer number of entities from IGDB matching the query
          */
-        public function search($query, $count = false) {
-            return $this->_exec_query($this->construct_url(__FUNCTION__, $count), $query);
+        public function search_count($query) {
+            return $this->_exec_query($this->construct_url('search', true), $query)->count;
         }
 
         /**
          * Video game themes
          *
-         * Depending on $count, the method will either return:
-         *  - <code>TRUE</code>: an object containing a <code>count</code> property with the number of matched records
-         *  - <code>FALSE</code>: an array of objects, containing the matched records from IGDB
+         * @link https://api-docs.igdb.com/#theme
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result array entities from IGDB matching the query
+         */
+        public function theme($query) {
+            return $this->_exec_query($this->construct_url('theme', false), $query);
+        }
+
+        /**
+         * Video game themes
          *
          * @link https://api-docs.igdb.com/#theme
          *
-         * @param $query ( string ) an apicalypse query string to send to the IGDB server
-         * @param $count ( boolean ) whether the method should return the results or their count.
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
          * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @return $result ( array | object ) response from IGDB
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result integer number of entities from IGDB matching the query
          */
-        public function theme($query, $count = false) {
-            return $this->_exec_query($this->construct_url(__FUNCTION__, $count), $query);
+        public function theme_count($query) {
+            return $this->_exec_query($this->construct_url('theme', true), $query)->count;
         }
 
         /**
          * A website url, usually associated with a game
          *
-         * Depending on $count, the method will either return:
-         *  - <code>TRUE</code>: an object containing a <code>count</code> property with the number of matched records
-         *  - <code>FALSE</code>: an array of objects, containing the matched records from IGDB
+         * @link https://api-docs.igdb.com/#website
+         *
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
+         * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result array entities from IGDB matching the query
+         */
+        public function website($query) {
+            return $this->_exec_query($this->construct_url('website', false), $query);
+        }
+
+        /**
+         * A website url, usually associated with a game
          *
          * @link https://api-docs.igdb.com/#website
          *
-         * @param $query ( string ) an apicalypse query string to send to the IGDB server
-         * @param $count ( boolean ) whether the method should return the results or their count.
+         * @param $query ( string | IGDBQueryBuilder ) either an apicalypse string or IGDBQueryBuilder instance
          * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
-         * @return $result ( array | object ) response from IGDB
+         * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
+         * @return $result integer number of entities from IGDB matching the query
          */
-        public function website($query, $count = false) {
-            return $this->_exec_query($this->construct_url(__FUNCTION__, $count), $query);
+        public function website_count($query) {
+            return $this->_exec_query($this->construct_url('website', true), $query)->count;
         }
     }
 ?>

--- a/src/IGDB.php
+++ b/src/IGDB.php
@@ -9,6 +9,7 @@
      * @version 5.0.0
      * @author Enisz Abdalla <enisz87@gmail.com>
      * @link https://github.com/enisz/igdb
+     * @link https://enisz.github.io/igdb
      */
 
     require_once "IGDBEndpointException.php";
@@ -82,7 +83,7 @@
             if(array_key_exists($endpoint, IGDBW_ENDPOINTS)) {
                 return rtrim(IGDBW_API_URL, "/") . "/" . IGDBW_ENDPOINTS[$endpoint] . ($count ? "/count" : "");
             } else {
-                throw new IGDBInvalidParameterException("Invalid Endpoint name " . $endpoint . "!");
+                throw new IGDBInvalidParameterException("Invalid Endpoint name $endpoint!");
             }
         }
 
@@ -171,7 +172,7 @@
          *
          * @link https://api-docs.igdb.com/#multi-query
          *
-         * @param $queries ( array of strings ) The queries to send to the multiquery endpoint as an array of multiquery formatted apicalypse strings.
+         * @param $queries ( string[] | IGDBQueryBuilder[] ) The queries to send to the multiquery endpoint as an array of multiquery formatted apicalypse strings or configured IGDBQueryBuilder instances
          * @return $result ( mixed ) The result of the query.
          * @throws IGDBEndpointException if the response code is non successful (successful range is from 200 to 299)
          * @throws IGDBInvalidParameterException If not array of strings or IGDBQueryBuilder instances are passed as a parameter
@@ -182,7 +183,7 @@
             if(is_array($queries)) {
                 foreach($queries as $index => $query) {
                     if(!is_string($query) && !($query instanceof IGDBQueryBuilder)) {
-                        throw new IGDBInvalidParameterException("Invalid type of parameter for multiquery! An array of strings or IGDBQueryBuilder instances are expected, " . gettype($query) . " passed at index " . $index . "!");
+                        throw new IGDBInvalidParameterException("Invalid type of parameter for multiquery! An array of strings or IGDBQueryBuilder instances are expected, " . gettype($query) . " passed at index $index!");
                     }
 
                     array_push($prepared, is_string($query) ? $query : $query->build_multiquery());
@@ -205,7 +206,7 @@
          * @return $result array entities from IGDB matching the query
          */
         public function age_rating($query) {
-            return $this->_exec_query($this->construct_url('age_rating', false), $query);
+            return $this->_exec_query($this->construct_url("age_rating", false), $query);
         }
 
         /**
@@ -218,8 +219,8 @@
          * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @return $result integer number of entities from IGDB matching the query
          */
-        public function age_rating_count($query) {
-            return $this->_exec_query($this->construct_url('age_rating', true), $query)->count;
+        public function age_rating_count($query = "") {
+            return $this->_exec_query($this->construct_url("age_rating", true), $query)->count;
         }
 
         /**
@@ -233,7 +234,7 @@
          * @return $result array entities from IGDB matching the query
          */
         public function age_rating_content_description($query) {
-            return $this->_exec_query($this->construct_url('age_rating_content_description', false), $query);
+            return $this->_exec_query($this->construct_url("age_rating_content_description", false), $query);
         }
 
         /**
@@ -246,8 +247,8 @@
          * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @return $result integer number of entities from IGDB matching the query
          */
-        public function age_rating_content_description_count($query) {
-            return $this->_exec_query($this->construct_url('age_rating_content_description', true), $query)->count;
+        public function age_rating_content_description_count($query = "") {
+            return $this->_exec_query($this->construct_url("age_rating_content_description", true), $query)->count;
         }
 
         /**
@@ -261,7 +262,7 @@
          * @return $result array entities from IGDB matching the query
          */
         public function alternative_name($query) {
-            return $this->_exec_query($this->construct_url('alternative_name', false), $query);
+            return $this->_exec_query($this->construct_url("alternative_name", false), $query);
         }
 
         /**
@@ -274,8 +275,8 @@
          * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @return $result integer number of entities from IGDB matching the query
          */
-        public function alternative_name_count($query) {
-            return $this->_exec_query($this->construct_url('alternative_name', true), $query)->count;
+        public function alternative_name_count($query = "") {
+            return $this->_exec_query($this->construct_url("alternative_name", true), $query)->count;
         }
 
         /**
@@ -289,7 +290,7 @@
          * @return $result array entities from IGDB matching the query
          */
         public function artwork($query) {
-            return $this->_exec_query($this->construct_url('artwork', false), $query);
+            return $this->_exec_query($this->construct_url("artwork", false), $query);
         }
 
         /**
@@ -302,8 +303,8 @@
          * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @return $result integer number of entities from IGDB matching the query
          */
-        public function artwork_count($query) {
-            return $this->_exec_query($this->construct_url('artwork', true), $query)->count;
+        public function artwork_count($query = "") {
+            return $this->_exec_query($this->construct_url("artwork", true), $query)->count;
         }
 
         /**
@@ -317,7 +318,7 @@
          * @return $result array entities from IGDB matching the query
          */
         public function character($query) {
-            return $this->_exec_query($this->construct_url('character', false), $query);
+            return $this->_exec_query($this->construct_url("character", false), $query);
         }
 
         /**
@@ -330,8 +331,8 @@
          * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @return $result integer number of entities from IGDB matching the query
          */
-        public function character_count($query) {
-            return $this->_exec_query($this->construct_url('character', true), $query)->count;
+        public function character_count($query = "") {
+            return $this->_exec_query($this->construct_url("character", true), $query)->count;
         }
 
         /**
@@ -345,7 +346,7 @@
          * @return $result array entities from IGDB matching the query
          */
         public function character_mug_shot($query) {
-            return $this->_exec_query($this->construct_url('character_mug_shot', false), $query);
+            return $this->_exec_query($this->construct_url("character_mug_shot", false), $query);
         }
 
         /**
@@ -358,8 +359,8 @@
          * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @return $result integer number of entities from IGDB matching the query
          */
-        public function character_mug_shot_count($query) {
-            return $this->_exec_query($this->construct_url('character_mug_shot', true), $query)->count;
+        public function character_mug_shot_count($query = "") {
+            return $this->_exec_query($this->construct_url("character_mug_shot", true), $query)->count;
         }
 
         /**
@@ -373,7 +374,7 @@
          * @return $result array entities from IGDB matching the query
          */
         public function collection($query) {
-            return $this->_exec_query($this->construct_url('collection', false), $query);
+            return $this->_exec_query($this->construct_url("collection", false), $query);
         }
 
         /**
@@ -386,8 +387,8 @@
          * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @return $result integer number of entities from IGDB matching the query
          */
-        public function collection_count($query) {
-            return $this->_exec_query($this->construct_url('collection', true), $query)->count;
+        public function collection_count($query = "") {
+            return $this->_exec_query($this->construct_url("collection", true), $query)->count;
         }
 
         /**
@@ -401,7 +402,7 @@
          * @return $result array entities from IGDB matching the query
          */
         public function collection_membership($query) {
-            return $this->_exec_query($this->construct_url('collection_membership', false), $query);
+            return $this->_exec_query($this->construct_url("collection_membership", false), $query);
         }
 
         /**
@@ -414,8 +415,8 @@
          * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @return $result integer number of entities from IGDB matching the query
          */
-        public function collection_membership_count($query) {
-            return $this->_exec_query($this->construct_url('collection_membership', true), $query)->count;
+        public function collection_membership_count($query = "") {
+            return $this->_exec_query($this->construct_url("collection_membership", true), $query)->count;
         }
 
         /**
@@ -429,7 +430,7 @@
          * @return $result array entities from IGDB matching the query
          */
         public function collection_membership_type($query) {
-            return $this->_exec_query($this->construct_url('collection_membership_type', false), $query);
+            return $this->_exec_query($this->construct_url("collection_membership_type", false), $query);
         }
 
         /**
@@ -442,8 +443,8 @@
          * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @return $result integer number of entities from IGDB matching the query
          */
-        public function collection_membership_type_count($query) {
-            return $this->_exec_query($this->construct_url('collection_membership_type', true), $query)->count;
+        public function collection_membership_type_count($query = "") {
+            return $this->_exec_query($this->construct_url("collection_membership_type", true), $query)->count;
         }
 
         /**
@@ -457,7 +458,7 @@
          * @return $result array entities from IGDB matching the query
          */
         public function collection_relation($query) {
-            return $this->_exec_query($this->construct_url('collection_relation', false), $query);
+            return $this->_exec_query($this->construct_url("collection_relation", false), $query);
         }
 
         /**
@@ -470,8 +471,8 @@
          * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @return $result integer number of entities from IGDB matching the query
          */
-        public function collection_relation_count($query) {
-            return $this->_exec_query($this->construct_url('collection_relation', true), $query)->count;
+        public function collection_relation_count($query = "") {
+            return $this->_exec_query($this->construct_url("collection_relation", true), $query)->count;
         }
 
         /**
@@ -485,7 +486,7 @@
          * @return $result array entities from IGDB matching the query
          */
         public function collection_relation_type($query) {
-            return $this->_exec_query($this->construct_url('collection_relation_type', false), $query);
+            return $this->_exec_query($this->construct_url("collection_relation_type", false), $query);
         }
 
         /**
@@ -498,8 +499,8 @@
          * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @return $result integer number of entities from IGDB matching the query
          */
-        public function collection_relation_type_count($query) {
-            return $this->_exec_query($this->construct_url('collection_relation_type', true), $query)->count;
+        public function collection_relation_type_count($query = "") {
+            return $this->_exec_query($this->construct_url("collection_relation_type", true), $query)->count;
         }
 
         /**
@@ -513,7 +514,7 @@
          * @return $result array entities from IGDB matching the query
          */
         public function collection_type($query) {
-            return $this->_exec_query($this->construct_url('collection_type', false), $query);
+            return $this->_exec_query($this->construct_url("collection_type", false), $query);
         }
 
         /**
@@ -526,8 +527,8 @@
          * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @return $result integer number of entities from IGDB matching the query
          */
-        public function collection_type_count($query) {
-            return $this->_exec_query($this->construct_url('collection_type', true), $query)->count;
+        public function collection_type_count($query = "") {
+            return $this->_exec_query($this->construct_url("collection_type", true), $query)->count;
         }
 
         /**
@@ -541,7 +542,7 @@
          * @return $result array entities from IGDB matching the query
          */
         public function company($query) {
-            return $this->_exec_query($this->construct_url('company', false), $query);
+            return $this->_exec_query($this->construct_url("company", false), $query);
         }
 
         /**
@@ -554,8 +555,8 @@
          * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @return $result integer number of entities from IGDB matching the query
          */
-        public function company_count($query) {
-            return $this->_exec_query($this->construct_url('company', true), $query)->count;
+        public function company_count($query = "") {
+            return $this->_exec_query($this->construct_url("company", true), $query)->count;
         }
 
         /**
@@ -569,7 +570,7 @@
          * @return $result array entities from IGDB matching the query
          */
         public function company_logo($query) {
-            return $this->_exec_query($this->construct_url('company_logo', false), $query);
+            return $this->_exec_query($this->construct_url("company_logo", false), $query);
         }
 
         /**
@@ -582,8 +583,8 @@
          * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @return $result integer number of entities from IGDB matching the query
          */
-        public function company_logo_count($query) {
-            return $this->_exec_query($this->construct_url('company_logo', true), $query)->count;
+        public function company_logo_count($query = "") {
+            return $this->_exec_query($this->construct_url("company_logo", true), $query)->count;
         }
 
         /**
@@ -597,7 +598,7 @@
          * @return $result array entities from IGDB matching the query
          */
         public function company_website($query) {
-            return $this->_exec_query($this->construct_url('company_website', false), $query);
+            return $this->_exec_query($this->construct_url("company_website", false), $query);
         }
 
         /**
@@ -610,8 +611,8 @@
          * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @return $result integer number of entities from IGDB matching the query
          */
-        public function company_website_count($query) {
-            return $this->_exec_query($this->construct_url('company_website', true), $query)->count;
+        public function company_website_count($query = "") {
+            return $this->_exec_query($this->construct_url("company_website", true), $query)->count;
         }
 
         /**
@@ -625,7 +626,7 @@
          * @return $result array entities from IGDB matching the query
          */
         public function cover($query) {
-            return $this->_exec_query($this->construct_url('cover', false), $query);
+            return $this->_exec_query($this->construct_url("cover", false), $query);
         }
 
         /**
@@ -638,8 +639,8 @@
          * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @return $result integer number of entities from IGDB matching the query
          */
-        public function cover_count($query) {
-            return $this->_exec_query($this->construct_url('cover', true), $query)->count;
+        public function cover_count($query = "") {
+            return $this->_exec_query($this->construct_url("cover", true), $query)->count;
         }
 
         /**
@@ -653,7 +654,7 @@
          * @return $result array entities from IGDB matching the query
          */
         public function event($query) {
-            return $this->_exec_query($this->construct_url('event', false), $query);
+            return $this->_exec_query($this->construct_url("event", false), $query);
         }
 
         /**
@@ -666,8 +667,8 @@
          * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @return $result integer number of entities from IGDB matching the query
          */
-        public function event_count($query) {
-            return $this->_exec_query($this->construct_url('event', true), $query)->count;
+        public function event_count($query = "") {
+            return $this->_exec_query($this->construct_url("event", true), $query)->count;
         }
 
         /**
@@ -681,7 +682,7 @@
          * @return $result array entities from IGDB matching the query
          */
         public function event_logo($query) {
-            return $this->_exec_query($this->construct_url('event_logo', false), $query);
+            return $this->_exec_query($this->construct_url("event_logo", false), $query);
         }
 
         /**
@@ -694,8 +695,8 @@
          * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @return $result integer number of entities from IGDB matching the query
          */
-        public function event_logo_count($query) {
-            return $this->_exec_query($this->construct_url('event_logo', true), $query)->count;
+        public function event_logo_count($query = "") {
+            return $this->_exec_query($this->construct_url("event_logo", true), $query)->count;
         }
 
         /**
@@ -709,7 +710,7 @@
          * @return $result array entities from IGDB matching the query
          */
         public function event_network($query) {
-            return $this->_exec_query($this->construct_url('event_network', false), $query);
+            return $this->_exec_query($this->construct_url("event_network", false), $query);
         }
 
         /**
@@ -722,8 +723,8 @@
          * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @return $result integer number of entities from IGDB matching the query
          */
-        public function event_network_count($query) {
-            return $this->_exec_query($this->construct_url('event_network', true), $query)->count;
+        public function event_network_count($query = "") {
+            return $this->_exec_query($this->construct_url("event_network", true), $query)->count;
         }
 
         /**
@@ -737,7 +738,7 @@
          * @return $result array entities from IGDB matching the query
          */
         public function external_game($query) {
-            return $this->_exec_query($this->construct_url('external_game', false), $query);
+            return $this->_exec_query($this->construct_url("external_game", false), $query);
         }
 
         /**
@@ -750,8 +751,8 @@
          * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @return $result integer number of entities from IGDB matching the query
          */
-        public function external_game_count($query) {
-            return $this->_exec_query($this->construct_url('external_game', true), $query)->count;
+        public function external_game_count($query = "") {
+            return $this->_exec_query($this->construct_url("external_game", true), $query)->count;
         }
 
         /**
@@ -765,7 +766,7 @@
          * @return $result array entities from IGDB matching the query
          */
         public function franchise($query) {
-            return $this->_exec_query($this->construct_url('franchise', false), $query);
+            return $this->_exec_query($this->construct_url("franchise", false), $query);
         }
 
         /**
@@ -778,8 +779,8 @@
          * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @return $result integer number of entities from IGDB matching the query
          */
-        public function franchise_count($query) {
-            return $this->_exec_query($this->construct_url('franchise', true), $query)->count;
+        public function franchise_count($query = "") {
+            return $this->_exec_query($this->construct_url("franchise", true), $query)->count;
         }
 
         /**
@@ -793,7 +794,7 @@
          * @return $result array entities from IGDB matching the query
          */
         public function game($query) {
-            return $this->_exec_query($this->construct_url('game', false), $query);
+            return $this->_exec_query($this->construct_url("game", false), $query);
         }
 
         /**
@@ -806,8 +807,8 @@
          * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @return $result integer number of entities from IGDB matching the query
          */
-        public function game_count($query) {
-            return $this->_exec_query($this->construct_url('game', true), $query)->count;
+        public function game_count($query = "") {
+            return $this->_exec_query($this->construct_url("game", true), $query)->count;
         }
 
         /**
@@ -821,7 +822,7 @@
          * @return $result array entities from IGDB matching the query
          */
         public function game_engine($query) {
-            return $this->_exec_query($this->construct_url('game_engine', false), $query);
+            return $this->_exec_query($this->construct_url("game_engine", false), $query);
         }
 
         /**
@@ -834,8 +835,8 @@
          * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @return $result integer number of entities from IGDB matching the query
          */
-        public function game_engine_count($query) {
-            return $this->_exec_query($this->construct_url('game_engine', true), $query)->count;
+        public function game_engine_count($query = "") {
+            return $this->_exec_query($this->construct_url("game_engine", true), $query)->count;
         }
 
         /**
@@ -849,7 +850,7 @@
          * @return $result array entities from IGDB matching the query
          */
         public function game_engine_logo($query) {
-            return $this->_exec_query($this->construct_url('game_engine_logo', false), $query);
+            return $this->_exec_query($this->construct_url("game_engine_logo", false), $query);
         }
 
         /**
@@ -862,8 +863,8 @@
          * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @return $result integer number of entities from IGDB matching the query
          */
-        public function game_engine_logo_count($query) {
-            return $this->_exec_query($this->construct_url('game_engine_logo', true), $query)->count;
+        public function game_engine_logo_count($query = "") {
+            return $this->_exec_query($this->construct_url("game_engine_logo", true), $query)->count;
         }
 
         /**
@@ -877,7 +878,7 @@
          * @return $result array entities from IGDB matching the query
          */
         public function game_localization($query) {
-            return $this->_exec_query($this->construct_url('game_localization', false), $query);
+            return $this->_exec_query($this->construct_url("game_localization", false), $query);
         }
 
         /**
@@ -890,8 +891,8 @@
          * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @return $result integer number of entities from IGDB matching the query
          */
-        public function game_localization_count($query) {
-            return $this->_exec_query($this->construct_url('game_localization', true), $query)->count;
+        public function game_localization_count($query = "") {
+            return $this->_exec_query($this->construct_url("game_localization", true), $query)->count;
         }
 
         /**
@@ -905,7 +906,7 @@
          * @return $result array entities from IGDB matching the query
          */
         public function game_mode($query) {
-            return $this->_exec_query($this->construct_url('game_mode', false), $query);
+            return $this->_exec_query($this->construct_url("game_mode", false), $query);
         }
 
         /**
@@ -918,8 +919,8 @@
          * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @return $result integer number of entities from IGDB matching the query
          */
-        public function game_mode_count($query) {
-            return $this->_exec_query($this->construct_url('game_mode', true), $query)->count;
+        public function game_mode_count($query = "") {
+            return $this->_exec_query($this->construct_url("game_mode", true), $query)->count;
         }
 
         /**
@@ -933,7 +934,7 @@
          * @return $result array entities from IGDB matching the query
          */
         public function game_version($query) {
-            return $this->_exec_query($this->construct_url('game_version', false), $query);
+            return $this->_exec_query($this->construct_url("game_version", false), $query);
         }
 
         /**
@@ -946,8 +947,8 @@
          * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @return $result integer number of entities from IGDB matching the query
          */
-        public function game_version_count($query) {
-            return $this->_exec_query($this->construct_url('game_version', true), $query)->count;
+        public function game_version_count($query = "") {
+            return $this->_exec_query($this->construct_url("game_version", true), $query)->count;
         }
 
         /**
@@ -961,7 +962,7 @@
          * @return $result array entities from IGDB matching the query
          */
         public function game_version_feature($query) {
-            return $this->_exec_query($this->construct_url('game_version_feature', false), $query);
+            return $this->_exec_query($this->construct_url("game_version_feature", false), $query);
         }
 
         /**
@@ -974,8 +975,8 @@
          * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @return $result integer number of entities from IGDB matching the query
          */
-        public function game_version_feature_count($query) {
-            return $this->_exec_query($this->construct_url('game_version_feature', true), $query)->count;
+        public function game_version_feature_count($query = "") {
+            return $this->_exec_query($this->construct_url("game_version_feature", true), $query)->count;
         }
 
         /**
@@ -989,7 +990,7 @@
          * @return $result array entities from IGDB matching the query
          */
         public function game_version_feature_value($query) {
-            return $this->_exec_query($this->construct_url('game_version_feature_value', false), $query);
+            return $this->_exec_query($this->construct_url("game_version_feature_value", false), $query);
         }
 
         /**
@@ -1002,8 +1003,8 @@
          * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @return $result integer number of entities from IGDB matching the query
          */
-        public function game_version_feature_value_count($query) {
-            return $this->_exec_query($this->construct_url('game_version_feature_value', true), $query)->count;
+        public function game_version_feature_value_count($query = "") {
+            return $this->_exec_query($this->construct_url("game_version_feature_value", true), $query)->count;
         }
 
         /**
@@ -1017,7 +1018,7 @@
          * @return $result array entities from IGDB matching the query
          */
         public function game_video($query) {
-            return $this->_exec_query($this->construct_url('game_video', false), $query);
+            return $this->_exec_query($this->construct_url("game_video", false), $query);
         }
 
         /**
@@ -1030,8 +1031,8 @@
          * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @return $result integer number of entities from IGDB matching the query
          */
-        public function game_video_count($query) {
-            return $this->_exec_query($this->construct_url('game_video', true), $query)->count;
+        public function game_video_count($query = "") {
+            return $this->_exec_query($this->construct_url("game_video", true), $query)->count;
         }
 
         /**
@@ -1045,7 +1046,7 @@
          * @return $result array entities from IGDB matching the query
          */
         public function genre($query) {
-            return $this->_exec_query($this->construct_url('genre', false), $query);
+            return $this->_exec_query($this->construct_url("genre", false), $query);
         }
 
         /**
@@ -1058,8 +1059,8 @@
          * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @return $result integer number of entities from IGDB matching the query
          */
-        public function genre_count($query) {
-            return $this->_exec_query($this->construct_url('genre', true), $query)->count;
+        public function genre_count($query = "") {
+            return $this->_exec_query($this->construct_url("genre", true), $query)->count;
         }
 
         /**
@@ -1073,7 +1074,7 @@
          * @return $result array entities from IGDB matching the query
          */
         public function involved_company($query) {
-            return $this->_exec_query($this->construct_url('involved_company', false), $query);
+            return $this->_exec_query($this->construct_url("involved_company", false), $query);
         }
 
         /**
@@ -1086,8 +1087,8 @@
          * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @return $result integer number of entities from IGDB matching the query
          */
-        public function involved_company_count($query) {
-            return $this->_exec_query($this->construct_url('involved_company', true), $query)->count;
+        public function involved_company_count($query = "") {
+            return $this->_exec_query($this->construct_url("involved_company", true), $query)->count;
         }
 
         /**
@@ -1101,7 +1102,7 @@
          * @return $result array entities from IGDB matching the query
          */
         public function keyword($query) {
-            return $this->_exec_query($this->construct_url('keyword', false), $query);
+            return $this->_exec_query($this->construct_url("keyword", false), $query);
         }
 
         /**
@@ -1114,8 +1115,8 @@
          * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @return $result integer number of entities from IGDB matching the query
          */
-        public function keyword_count($query) {
-            return $this->_exec_query($this->construct_url('keyword', true), $query)->count;
+        public function keyword_count($query = "") {
+            return $this->_exec_query($this->construct_url("keyword", true), $query)->count;
         }
 
         /**
@@ -1129,7 +1130,7 @@
          * @return $result array entities from IGDB matching the query
          */
         public function language_support($query) {
-            return $this->_exec_query($this->construct_url('language_support', false), $query);
+            return $this->_exec_query($this->construct_url("language_support", false), $query);
         }
 
         /**
@@ -1142,8 +1143,8 @@
          * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @return $result integer number of entities from IGDB matching the query
          */
-        public function language_support_count($query) {
-            return $this->_exec_query($this->construct_url('language_support', true), $query)->count;
+        public function language_support_count($query = "") {
+            return $this->_exec_query($this->construct_url("language_support", true), $query)->count;
         }
 
         /**
@@ -1157,7 +1158,7 @@
          * @return $result array entities from IGDB matching the query
          */
         public function language_support_type($query) {
-            return $this->_exec_query($this->construct_url('language_support_type', false), $query);
+            return $this->_exec_query($this->construct_url("language_support_type", false), $query);
         }
 
         /**
@@ -1170,8 +1171,8 @@
          * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @return $result integer number of entities from IGDB matching the query
          */
-        public function language_support_type_count($query) {
-            return $this->_exec_query($this->construct_url('language_support_type', true), $query)->count;
+        public function language_support_type_count($query = "") {
+            return $this->_exec_query($this->construct_url("language_support_type", true), $query)->count;
         }
 
         /**
@@ -1185,7 +1186,7 @@
          * @return $result array entities from IGDB matching the query
          */
         public function language($query) {
-            return $this->_exec_query($this->construct_url('language', false), $query);
+            return $this->_exec_query($this->construct_url("language", false), $query);
         }
 
         /**
@@ -1198,8 +1199,8 @@
          * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @return $result integer number of entities from IGDB matching the query
          */
-        public function language_count($query) {
-            return $this->_exec_query($this->construct_url('language', true), $query)->count;
+        public function language_count($query = "") {
+            return $this->_exec_query($this->construct_url("language", true), $query)->count;
         }
 
         /**
@@ -1213,7 +1214,7 @@
          * @return $result array entities from IGDB matching the query
          */
         public function multiplayer_mode($query) {
-            return $this->_exec_query($this->construct_url('multiplayer_mode', false), $query);
+            return $this->_exec_query($this->construct_url("multiplayer_mode", false), $query);
         }
 
         /**
@@ -1226,8 +1227,8 @@
          * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @return $result integer number of entities from IGDB matching the query
          */
-        public function multiplayer_mode_count($query) {
-            return $this->_exec_query($this->construct_url('multiplayer_mode', true), $query)->count;
+        public function multiplayer_mode_count($query = "") {
+            return $this->_exec_query($this->construct_url("multiplayer_mode", true), $query)->count;
         }
 
         /**
@@ -1241,7 +1242,7 @@
          * @return $result array entities from IGDB matching the query
          */
         public function network_type($query) {
-            return $this->_exec_query($this->construct_url('network_type', false), $query);
+            return $this->_exec_query($this->construct_url("network_type", false), $query);
         }
 
         /**
@@ -1254,8 +1255,8 @@
          * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @return $result integer number of entities from IGDB matching the query
          */
-        public function network_type_count($query) {
-            return $this->_exec_query($this->construct_url('network_type', true), $query)->count;
+        public function network_type_count($query = "") {
+            return $this->_exec_query($this->construct_url("network_type", true), $query)->count;
         }
 
         /**
@@ -1269,7 +1270,7 @@
          * @return $result array entities from IGDB matching the query
          */
         public function platform($query) {
-            return $this->_exec_query($this->construct_url('platform', false), $query);
+            return $this->_exec_query($this->construct_url("platform", false), $query);
         }
 
         /**
@@ -1282,8 +1283,8 @@
          * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @return $result integer number of entities from IGDB matching the query
          */
-        public function platform_count($query) {
-            return $this->_exec_query($this->construct_url('platform', true), $query)->count;
+        public function platform_count($query = "") {
+            return $this->_exec_query($this->construct_url("platform", true), $query)->count;
         }
 
         /**
@@ -1297,7 +1298,7 @@
          * @return $result array entities from IGDB matching the query
          */
         public function platform_family($query) {
-            return $this->_exec_query($this->construct_url('platform_family', false), $query);
+            return $this->_exec_query($this->construct_url("platform_family", false), $query);
         }
 
         /**
@@ -1310,8 +1311,8 @@
          * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @return $result integer number of entities from IGDB matching the query
          */
-        public function platform_family_count($query) {
-            return $this->_exec_query($this->construct_url('platform_family', true), $query)->count;
+        public function platform_family_count($query = "") {
+            return $this->_exec_query($this->construct_url("platform_family", true), $query)->count;
         }
 
         /**
@@ -1325,7 +1326,7 @@
          * @return $result array entities from IGDB matching the query
          */
         public function platform_logo($query) {
-            return $this->_exec_query($this->construct_url('platform_logo', false), $query);
+            return $this->_exec_query($this->construct_url("platform_logo", false), $query);
         }
 
         /**
@@ -1338,8 +1339,8 @@
          * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @return $result integer number of entities from IGDB matching the query
          */
-        public function platform_logo_count($query) {
-            return $this->_exec_query($this->construct_url('platform_logo', true), $query)->count;
+        public function platform_logo_count($query = "") {
+            return $this->_exec_query($this->construct_url("platform_logo", true), $query)->count;
         }
 
         /**
@@ -1353,7 +1354,7 @@
          * @return $result array entities from IGDB matching the query
          */
         public function platform_version($query) {
-            return $this->_exec_query($this->construct_url('platform_version', false), $query);
+            return $this->_exec_query($this->construct_url("platform_version", false), $query);
         }
 
         /**
@@ -1366,8 +1367,8 @@
          * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @return $result integer number of entities from IGDB matching the query
          */
-        public function platform_version_count($query) {
-            return $this->_exec_query($this->construct_url('platform_version', true), $query)->count;
+        public function platform_version_count($query = "") {
+            return $this->_exec_query($this->construct_url("platform_version", true), $query)->count;
         }
 
         /**
@@ -1381,7 +1382,7 @@
          * @return $result array entities from IGDB matching the query
          */
         public function platform_version_company($query) {
-            return $this->_exec_query($this->construct_url('platform_version_company', false), $query);
+            return $this->_exec_query($this->construct_url("platform_version_company", false), $query);
         }
 
         /**
@@ -1394,8 +1395,8 @@
          * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @return $result integer number of entities from IGDB matching the query
          */
-        public function platform_version_company_count($query) {
-            return $this->_exec_query($this->construct_url('platform_version_company', true), $query)->count;
+        public function platform_version_company_count($query = "") {
+            return $this->_exec_query($this->construct_url("platform_version_company", true), $query)->count;
         }
 
         /**
@@ -1409,7 +1410,7 @@
          * @return $result array entities from IGDB matching the query
          */
         public function platform_version_release_date($query) {
-            return $this->_exec_query($this->construct_url('platform_version_release_date', false), $query);
+            return $this->_exec_query($this->construct_url("platform_version_release_date", false), $query);
         }
 
         /**
@@ -1422,8 +1423,8 @@
          * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @return $result integer number of entities from IGDB matching the query
          */
-        public function platform_version_release_date_count($query) {
-            return $this->_exec_query($this->construct_url('platform_version_release_date', true), $query)->count;
+        public function platform_version_release_date_count($query = "") {
+            return $this->_exec_query($this->construct_url("platform_version_release_date", true), $query)->count;
         }
 
         /**
@@ -1437,7 +1438,7 @@
          * @return $result array entities from IGDB matching the query
          */
         public function platform_website($query) {
-            return $this->_exec_query($this->construct_url('platform_website', false), $query);
+            return $this->_exec_query($this->construct_url("platform_website", false), $query);
         }
 
         /**
@@ -1450,8 +1451,8 @@
          * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @return $result integer number of entities from IGDB matching the query
          */
-        public function platform_website_count($query) {
-            return $this->_exec_query($this->construct_url('platform_website', true), $query)->count;
+        public function platform_website_count($query = "") {
+            return $this->_exec_query($this->construct_url("platform_website", true), $query)->count;
         }
 
         /**
@@ -1465,7 +1466,7 @@
          * @return $result array entities from IGDB matching the query
          */
         public function player_perspective($query) {
-            return $this->_exec_query($this->construct_url('player_perspective', false), $query);
+            return $this->_exec_query($this->construct_url("player_perspective", false), $query);
         }
 
         /**
@@ -1478,8 +1479,8 @@
          * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @return $result integer number of entities from IGDB matching the query
          */
-        public function player_perspective_count($query) {
-            return $this->_exec_query($this->construct_url('player_perspective', true), $query)->count;
+        public function player_perspective_count($query = "") {
+            return $this->_exec_query($this->construct_url("player_perspective", true), $query)->count;
         }
 
         /**
@@ -1493,7 +1494,7 @@
          * @return $result array entities from IGDB matching the query
          */
         public function region($query) {
-            return $this->_exec_query($this->construct_url('region', false), $query);
+            return $this->_exec_query($this->construct_url("region", false), $query);
         }
 
         /**
@@ -1506,8 +1507,8 @@
          * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @return $result integer number of entities from IGDB matching the query
          */
-        public function region_count($query) {
-            return $this->_exec_query($this->construct_url('region', true), $query)->count;
+        public function region_count($query = "") {
+            return $this->_exec_query($this->construct_url("region", true), $query)->count;
         }
 
         /**
@@ -1521,7 +1522,7 @@
          * @return $result array entities from IGDB matching the query
          */
         public function release_date($query) {
-            return $this->_exec_query($this->construct_url('release_date', false), $query);
+            return $this->_exec_query($this->construct_url("release_date", false), $query);
         }
 
         /**
@@ -1534,8 +1535,8 @@
          * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @return $result integer number of entities from IGDB matching the query
          */
-        public function release_date_count($query) {
-            return $this->_exec_query($this->construct_url('release_date', true), $query)->count;
+        public function release_date_count($query = "") {
+            return $this->_exec_query($this->construct_url("release_date", true), $query)->count;
         }
 
         /**
@@ -1549,7 +1550,7 @@
          * @return $result array entities from IGDB matching the query
          */
         public function release_date_status($query) {
-            return $this->_exec_query($this->construct_url('release_date_status', false), $query);
+            return $this->_exec_query($this->construct_url("release_date_status", false), $query);
         }
 
         /**
@@ -1562,8 +1563,8 @@
          * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @return $result integer number of entities from IGDB matching the query
          */
-        public function release_date_status_count($query) {
-            return $this->_exec_query($this->construct_url('release_date_status', true), $query)->count;
+        public function release_date_status_count($query = "") {
+            return $this->_exec_query($this->construct_url("release_date_status", true), $query)->count;
         }
 
         /**
@@ -1577,7 +1578,7 @@
          * @return $result array entities from IGDB matching the query
          */
         public function screenshot($query) {
-            return $this->_exec_query($this->construct_url('screenshot', false), $query);
+            return $this->_exec_query($this->construct_url("screenshot", false), $query);
         }
 
         /**
@@ -1590,8 +1591,8 @@
          * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @return $result integer number of entities from IGDB matching the query
          */
-        public function screenshot_count($query) {
-            return $this->_exec_query($this->construct_url('screenshot', true), $query)->count;
+        public function screenshot_count($query = "") {
+            return $this->_exec_query($this->construct_url("screenshot", true), $query)->count;
         }
 
         /**
@@ -1605,7 +1606,7 @@
          * @return $result array entities from IGDB matching the query
          */
         public function search($query) {
-            return $this->_exec_query($this->construct_url('search', false), $query);
+            return $this->_exec_query($this->construct_url("search", false), $query);
         }
 
         /**
@@ -1618,8 +1619,8 @@
          * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @return $result integer number of entities from IGDB matching the query
          */
-        public function search_count($query) {
-            return $this->_exec_query($this->construct_url('search', true), $query)->count;
+        public function search_count($query = "") {
+            return $this->_exec_query($this->construct_url("search", true), $query)->count;
         }
 
         /**
@@ -1633,7 +1634,7 @@
          * @return $result array entities from IGDB matching the query
          */
         public function theme($query) {
-            return $this->_exec_query($this->construct_url('theme', false), $query);
+            return $this->_exec_query($this->construct_url("theme", false), $query);
         }
 
         /**
@@ -1646,8 +1647,8 @@
          * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @return $result integer number of entities from IGDB matching the query
          */
-        public function theme_count($query) {
-            return $this->_exec_query($this->construct_url('theme', true), $query)->count;
+        public function theme_count($query = "") {
+            return $this->_exec_query($this->construct_url("theme", true), $query)->count;
         }
 
         /**
@@ -1661,7 +1662,7 @@
          * @return $result array entities from IGDB matching the query
          */
         public function website($query) {
-            return $this->_exec_query($this->construct_url('website', false), $query);
+            return $this->_exec_query($this->construct_url("website", false), $query);
         }
 
         /**
@@ -1674,8 +1675,8 @@
          * @throws IGDBInvalidParameterException if $query is not a string or an IGDBQueryBuilder instance
          * @return $result integer number of entities from IGDB matching the query
          */
-        public function website_count($query) {
-            return $this->_exec_query($this->construct_url('website', true), $query)->count;
+        public function website_count($query = "") {
+            return $this->_exec_query($this->construct_url("website", true), $query)->count;
         }
     }
 ?>

--- a/src/IGDBConstants.php
+++ b/src/IGDBConstants.php
@@ -1,5 +1,4 @@
 <?php
-    $sizes = array();
 
     define("IGDBW_ENDPOINTS", array(
         "age_rating" => "age_ratings",
@@ -85,6 +84,16 @@
         "create",
         "update",
         "delete"
+    ));
+
+    define('IGDBW_POSTFIXES', array(
+        "=",
+        "!=",
+        ">",
+        ">=",
+        "<",
+        "<=",
+        "~"
     ));
 
     define("IGDBW_API_URL", "https://api.igdb.com/v4");

--- a/src/IGDBConstants.php
+++ b/src/IGDBConstants.php
@@ -1,0 +1,92 @@
+<?php
+    $sizes = array();
+
+    define("IGDBW_ENDPOINTS", array(
+        "age_rating" => "age_ratings",
+        "age_rating_content_description" => "age_rating_content_descriptions",
+        "alternative_name" => "alternative_names",
+        "artwork" => "artworks",
+        "character" => "characters",
+        "character_mug_shot" => "character_mug_shots",
+        "collection" => "collections",
+        "collection_membership" => "collection_memberships",
+        "collection_membership_type" => "collection_membership_types",
+        "collection_relation" => "collection_relations",
+        "collection_relation_type" => "collection_relation_types",
+        "collection_type" => "collection_types",
+        "company" => "companies",
+        "company_logo" => "company_logos",
+        "company_website" => "company_websites",
+        "cover" => "covers",
+        "event" => "events",
+        "event_logo" => "event_logos",
+        "event_network" => "event_networks",
+        "external_game" => "external_games",
+        "franchise" => "franchises",
+        "game" => "games",
+        "game_engine" => "game_engines",
+        "game_engine_logo" => "game_engine_logos",
+        "game_localization" => "game_localizations",
+        "game_mode" => "game_modes",
+        "game_version" => "game_versions",
+        "game_version_feature" => "game_version_features",
+        "game_version_feature_value" => "game_version_feature_values",
+        "game_video" => "game_videos",
+        "genre" => "genres",
+        "involved_company" => "involved_companies",
+        "keyword" => "keywords",
+        "language_support" => "language_supports",
+        "language_support_type" => "language_support_types",
+        "language" => "languages",
+        "multiplayer_mode" => "multiplayer_modes",
+        "multiquery" => "multiquery",
+        "network_type" => "network_types",
+        "platform" => "platforms",
+        "platform_family" => "platform_families",
+        "platform_logo" => "platform_logos",
+        "platform_version" => "platform_versions",
+        "platform_version_company" => "platform_version_companies",
+        "platform_version_release_date" => "platform_version_release_dates",
+        "platform_website" => "platform_websites",
+        "player_perspective" => "player_perspectives",
+        "region" => "regions",
+        "release_date" => "release_dates",
+        "release_date_status" => "release_date_statuses",
+        "screenshot" => "screenshots",
+        "search" => "search",
+        "theme" => "themes",
+        "website" => "websites"
+    ));
+
+    define("IGDBW_IMAGE_SIZES", array(
+        "cover_small",
+        "cover_small_2x",
+        "screenshot_med",
+        "screenshot_med_2x",
+        "cover_big",
+        "cover_big_2x",
+        "logo_med",
+        "logo_med_2x",
+        "screenshot_big",
+        "screenshot_big_2x",
+        "screenshot_huge",
+        "screenshot_huge_2x",
+        "thumb",
+        "thumb_2x",
+        "micro",
+        "micro_2x",
+        "720p",
+        "720p_2x",
+        "1080p",
+        "1080p_2x"
+    ));
+
+    define("IGDBW_WEBHOOK_ACTIONS", array(
+        "create",
+        "update",
+        "delete"
+    ));
+
+    define("IGDBW_API_URL", "https://api.igdb.com/v4");
+
+?>

--- a/src/IGDBConstants.php
+++ b/src/IGDBConstants.php
@@ -98,4 +98,9 @@
 
     define("IGDBW_API_URL", "https://api.igdb.com/v4");
 
+    define("IGDBW_BUILDER_DEFAULTS", array(
+        "limit" => 10,
+        "offset" => 0
+    ));
+
 ?>

--- a/src/IGDBQueryBuilder.php
+++ b/src/IGDBQueryBuilder.php
@@ -65,16 +65,6 @@
         private $_count;
 
         /**
-         * Default value of the limit parameter
-         */
-        private $limit_default = 10;
-
-        /**
-         * Default value of the offset parameter
-         */
-        private $offset_default = 0;
-
-        /**
          * Setting up the builder with default values
          */
         public function __construct() {
@@ -88,8 +78,8 @@
             $this->_search = "";
             $this->_fields = array("*");
             $this->_exclude = array();
-            $this->_limit = $this->limit_default;
-            $this->_offset = $this->offset_default;
+            $this->_limit = IGDBW_BUILDER_DEFAULTS["limit"];
+            $this->_offset = IGDBW_BUILDER_DEFAULTS["offset"];
             $this->_where = array();
             $this->_sort = array();
             $this->_name = null;
@@ -450,7 +440,7 @@
 
                     case "limit":
                     case "offset":
-                        if($this->{"_" . $parameter} != $this->{$parameter . "_default"}) {
+                        if($this->{"_" . $parameter} != IGDBW_BUILDER_DEFAULTS[$parameter]) {
                             array_push($segments, $parameter . " " . $this->{"_" . $parameter});
                         }
                     break;

--- a/src/IGDBUtils.php
+++ b/src/IGDBUtils.php
@@ -30,10 +30,10 @@
             curl_setopt($ch, CURLOPT_URL, "https://id.twitch.tv/oauth2/token?client_id=$client_id&client_secret=$client_secret&grant_type=client_credentials");
 
             $response = json_decode(curl_exec($ch));
-            $responseCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+            $response_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
             curl_close($ch);
 
-            if($responseCode < 200 || $responseCode > 299) {
+            if($response_code < 200 || $response_code > 299) {
                 throw new Exception($response->message, $response->status);
             } else {
                 return $response;
@@ -92,11 +92,11 @@
             curl_setopt($ch, CURLOPT_POSTFIELDS, "url=$url&method=$method&secret=$secret");
 
             $response = json_decode(curl_exec($ch));
-            $responseCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+            $response_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
             curl_close($ch);
 
-            if($responseCode < 200 || $responseCode > 299) {
-                throw new Exception("Failed to create webhook!", $responseCode);
+            if($response_code < 200 || $response_code > 299) {
+                throw new Exception("Failed to create webhook!", $response_code);
             } else {
                 return $response;
             }
@@ -123,11 +123,11 @@
             ));
 
             $response = json_decode(curl_exec($ch));
-            $responseCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+            $response_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
             curl_close($ch);
 
-            if($responseCode < 200 || $responseCode > 299) {
-                throw new Exception("Failed to delete webhook!", $responseCode);
+            if($response_code < 200 || $response_code > 299) {
+                throw new Exception("Failed to delete webhook!", $response_code);
             } else {
                 return $response;
             }

--- a/src/class.igdb.php
+++ b/src/class.igdb.php
@@ -1,6 +1,7 @@
 <?php
 
     // Exposing all files for import from one file
+    require_once "IGDBConstants.php";
     require_once "IGDBEndpointException.php";
     require_once "IGDBInvalidParameterException.php";
     require_once "IGDBQueryBuilder.php";


### PR DESCRIPTION
 - IGDBUtils webhook support
 - IGDBQueryBuilder updates:
   - building standard and multiquery query strings is now separated to their respective methods:
     - `build`: standard apicalypse query
     - `build_multiquery`: multiquery query string
 - Wrapper updates:
   - synchronised API endpoints from IGDB, every available endpoint has its wrapper endpoint method counterpart
   - endpoint methods - and multiquery - now accept both an apicalypse query string or a configured IGDBQueryBuilder instance(s)
   - every endpoint method has its count counterpart. Count parameter is no longer available for the endpoint methods
   - multiple constant values are moved to a dedicated file `IGDBConstants.php`.